### PR TITLE
Reduce readme duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,24 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  readme:
+    name: Readme
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Generate readme
+        run: |
+          cargo install cargo-readme
+          make build-readme
+
+      - name: Validate readme changes are checked in
+        run: git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,10 @@ watch:
 
 watch_dummy:
 	cargo watch -s "cd dummy && cargo run"
+
+build: build-readme test
+	cargo build --release
+
+# Depends on `cargo-readme`: `cargo install cargo-readme`
+build-readme:
+	cargo readme -r nutype -i src/lib.rs -o README.md

--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@
 <a href="https://github.com/greyblake/nutype/actions/workflows/ci.yml" rel="nofollow"><img src="https://github.com/greyblake/nutype/actions/workflows/ci.yml/badge.svg" alt="Nutype Build Status"></a>
 <a href="https://docs.rs/nutype" rel="nofollow"><img src="https://docs.rs/nutype/badge.svg" alt="Nutype Documentation"></a>
 <a href="https://github.com/greyblake/nutype/discussions"><img src="https://img.shields.io/github/discussions/greyblake/nutype"/></a>
-<p>
+</p>
 
 ## Philosophy
 
 Nutype embraces the simple idea: **the type system can be leveraged to track the fact that something was done, so there is no need to do it again**.
 
-If a piece of data was once sanitized and validated we can rely on the types instead of sanitizing and validating again and again when we're in doubt.
-
+If a piece of data was once sanitized and validated we can rely on the types instead of sanitizing and validating again and again.
 
 ## Quick start
 
@@ -76,6 +75,8 @@ Here are some other examples of what you can do with `nutype`.
 You can skip `sanitize` and use a custom validator `with`:
 
 ```rust
+use nutype::nutype;
+
 #[nutype(validate(with = |n| n % 2 == 1))]
 struct OddNumber(i64);
 ```
@@ -83,15 +84,19 @@ struct OddNumber(i64);
 You can skip validation, if you need sanitization only:
 
 ```rust
+use nutype::nutype;
+
 #[nutype(sanitize(trim, lowercase))]
 struct Username(String);
 ```
 
-In that case `Username::new(String)` simply returns `Username`, not `Result`.
+In that case, `Username::new(String)` simply returns `Username`, not `Result`.
 
 You can derive traits. A lot of traits! For example:
 
 ```rust
+use nutype::nutype;
+
 #[nutype]
 #[derive(*)]
 struct Username(String);
@@ -188,24 +193,28 @@ The following traits can be derived for a float-based type:
 ## Custom sanitizers
 
 You can set custom sanitizers using the `with` option.
-A custom sanitizer is a function or closure that receives a value of an inner type with ownership and returns a sanitized value.
+A custom sanitizer is a function or closure that receives a value of an inner type with ownership and returns a sanitized value back.
 
 For example, this one
 
 ```rust
-#[nutype(sanitize(with = new_to_old))]
-pub struct CityName(String);
+use nutype::nutype;
 
 fn new_to_old(s: String) -> String {
     s.replace("New", "Old")
 }
+
+#[nutype(sanitize(with = new_to_old))]
+struct CityName(String);
 ```
 
 is equal to the following one:
 
 ```rust
+use nutype::nutype;
+
 #[nutype(sanitize(with = |s| s.replace("New", "Old") ))]
-pub struct CityName(String);
+struct CityName(String);
 ```
 
 And works the same way:
@@ -221,6 +230,8 @@ In similar fashion it's possible to define custom validators, but a validation f
 Think of it as a predicate.
 
 ```rust
+use nutype::nutype;
+
 #[nutype(validate(with = is_valid_name))]
 pub struct Name(String);
 
@@ -358,8 +369,6 @@ Thank you.
 * [refinement](https://docs.rs/refinement/latest/refinement/) - Convenient creation of type-safe refinement types (based on generics).
 * [semval](https://github.com/slowtec/semval) - Semantic validation for Rust.
 * [validator](https://github.com/Keats/validator) - Simple validation for Rust structs (powered by macros).
-
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ fn is_valid_name(name: &str) -> bool {
 The following snippet
 
 ```rust
+use nutype::nutype;
+
 #[nutype(
     sanitize(trim, lowercase)
     validate(present, max_len = 20)
@@ -295,12 +297,12 @@ mod __nutype_private_Username__ {
         // are built on top of this one.
         pub fn new(raw_username: impl Into<String>) -> Result<Username, UsernameError> {
             // Sanitize
-            let sanitized_username = raw_username.into().trim().lowercase();
+            let sanitized_username = raw_username.into().trim().to_lowercase();
 
             // Validate
-            if sanitized_username.empty() {
+            if sanitized_username.is_empty() {
                 Err(UsernameError::Missing)
-            } else if (sanitized_username.len() > 40 {
+            } else if sanitized_username.len() > 40 {
                 Err(UsernameError::TooLong)
             } else {
                 Ok(Username(sanitized_username))

--- a/nutype/README.tpl
+++ b/nutype/README.tpl
@@ -1,0 +1,5 @@
+{{readme}}
+
+## License
+
+{{license}} © [Sergey Potapov](https://www.greyblake.com)

--- a/nutype/src/lib.rs
+++ b/nutype/src/lib.rs
@@ -266,6 +266,8 @@
 //! The following snippet
 //!
 //! ```rust
+//! use nutype::nutype;
+//!
 //! #[nutype(
 //!     sanitize(trim, lowercase)
 //!     validate(present, max_len = 20)
@@ -295,12 +297,12 @@
 //!         // are built on top of this one.
 //!         pub fn new(raw_username: impl Into<String>) -> Result<Username, UsernameError> {
 //!             // Sanitize
-//!             let sanitized_username = raw_username.into().trim().lowercase();
+//!             let sanitized_username = raw_username.into().trim().to_lowercase();
 //!
 //!             // Validate
-//!             if sanitized_username.empty() {
+//!             if sanitized_username.is_empty() {
 //!                 Err(UsernameError::Missing)
-//!             } else if (sanitized_username.len() > 40 {
+//!             } else if sanitized_username.len() > 40 {
 //!                 Err(UsernameError::TooLong)
 //!             } else {
 //!                 Ok(Username(sanitized_username))

--- a/nutype/src/lib.rs
+++ b/nutype/src/lib.rs
@@ -1,13 +1,19 @@
 //! <p align="center"><img width="300" src="https://raw.githubusercontent.com/greyblake/nutype/master/art/rust_nutype.png" alt="Rust Nutype Logo"></p>
 //! <h2 align="center">The newtype with guarantees.</h2>
 //!
-//! ## Philosophy
+//! <p align="center">
+//! <a href="https://github.com/greyblake/nutype/actions/workflows/ci.yml" rel="nofollow"><img src="https://github.com/greyblake/nutype/actions/workflows/ci.yml/badge.svg" alt="Nutype Build Status"></a>
+//! <a href="https://docs.rs/nutype" rel="nofollow"><img src="https://docs.rs/nutype/badge.svg" alt="Nutype Documentation"></a>
+//! <a href="https://github.com/greyblake/nutype/discussions"><img src="https://img.shields.io/github/discussions/greyblake/nutype"/></a>
+//! </p>
+//!
+//! # Philosophy
 //!
 //! Nutype embraces the simple idea: **the type system can be leveraged to track the fact that something was done, so there is no need to do it again**.
 //!
 //! If a piece of data was once sanitized and validated we can rely on the types instead of sanitizing and validating again and again.
 //!
-//! ## Quick start
+//! # Quick start
 //!
 //! ```rust
 //! use nutype::nutype;
@@ -62,7 +68,7 @@
 //! Haha. It's does not seem to be easy!
 //!
 //!
-//! ## A few more examples
+//! # A few more examples
 //!
 //! Here are some other examples of what you can do with `nutype`.
 //!
@@ -102,18 +108,18 @@
 //! That would allow mutating the inner (protected) value which undermines the entire idea of nutype.
 //!
 //!
-//! ## Inner types
+//! # Inner types
 //!
 //! Available sanitizers, validators, and derivable traits are determined by the inner type, which falls into the following categories:
 //! * String
 //! * Integer (`u8`, `u16`,`u32`, `u64`, `u128`, `i8`, `i16`, `i32`, `i64`, `i128`, `usize`, `isize`)
 //! * Float (`f32`, `f64`)
 //!
-//! ## String
+//! # String
 //!
 //! At the moment the string inner type supports only `String` (owned) type.
 //!
-//! ### String sanitizers
+//! ## String sanitizers
 //!
 //! | Sanitizer   | Description                                                                         | Example                                         |
 //! |-------------|-------------------------------------------------------------------------------------|-------------------------------------------------|
@@ -122,7 +128,7 @@
 //! | `uppercase` | Converts the string to uppercase                                                    | `uppercase`                                     |
 //! | `with`      | Custom sanitizer. A function or closure that receives `String` and returns `String` | `with = \|mut s: String\| { s.truncate(5); s }` |
 //!
-//! ### String validators
+//! ## String validators
 //!
 //! | Validator | Description                                                                     | Error variant | Example                              |
 //! |-----------|---------------------------------------------------------------------------------|---------------|--------------------------------------|
@@ -131,23 +137,23 @@
 //! | `present` | Rejects an empty string                                                         | `Missing`     | `present`                            |
 //! | `with`    | Custom validator. A function or closure that receives `&str` and returns `bool` | `Invalid`     | `with = \|s: &str\| s.contains('@')` |
 //!
-//! ### String derivable traits
+//! ## String derivable traits
 //!
 //! The following traits can be derived for a string-based type:
 //! `Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `From`, `TryFrom`, `Into`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
 //!
 //!
-//! ## Integer
+//! # Integer
 //!
 //! The integer inner types are: `u8`, `u16`,`u32`, `u64`, `u128`, `i8`, `i16`, `i32`, `i64`, `i128`, `usize`, `isize`.
 //!
-//! ### Integer sanitizers
+//! ## Integer sanitizers
 //!
 //! | Sanitizer | Description       | Example                            |
 //! |-----------|-------------------|------------------------------------|
 //! | `with`    | Custom sanitizer. | `with = \|raw\| raw.clamp(0, 100)` |
 //!
-//! ### Integer validators
+//! ## Integer validators
 //!
 //! | Validator | Description         | Error variant | Example                       |
 //! |-----------|---------------------|---------------|-------------------------------|
@@ -155,23 +161,23 @@
 //! | `min`     | Minimum valid value | `TooSmall`    | `min = 18`                    |
 //! | `with`    | Custom validator    | `Invalid`     | `with = \|num\| num % 2 == 0` |
 //!
-//! ### Integer derivable traits
+//! ## Integer derivable traits
 //!
 //! The following traits can be derived for an integer-based type:
 //! `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
 //!
 //!
-//! ## Float
+//! # Float
 //!
 //! The float inner types are: `f32`, `f64`.
 //!
-//! ### Float sanitizers
+//! ## Float sanitizers
 //!
 //! | Sanitizer | Description       | Example                                |
 //! |-----------|-------------------|----------------------------------------|
 //! | `with`    | Custom sanitizer. | `with = \|val\| val.clamp(0.0, 100.0)` |
 //!
-//! ### Float validators
+//! ## Float validators
 //!
 //! | Validator | Description         | Error variant | Example                       |
 //! |-----------|---------------------|---------------|-------------------------------|
@@ -179,12 +185,12 @@
 //! | `min`     | Minimum valid value | `TooSmall`    | `min = 0.0`                   |
 //! | `with`    | Custom validator    | `Invalid`     | `with = \|val\| val != 50.0`  |
 //!
-//! ### Float derivable traits
+//! ## Float derivable traits
 //!
 //! The following traits can be derived for a float-based type:
 //! `Debug`, `Clone`, `Copy`, `PartialEq`, `PartialOrd`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
 //!
-//! ## Custom sanitizers
+//! # Custom sanitizers
 //!
 //! You can set custom sanitizers using the `with` option.
 //! A custom sanitizer is a function or closure that receives a value of an inner type with ownership and returns a sanitized value back.
@@ -218,7 +224,7 @@
 //! assert_eq!(city.into_inner(), "Old York");
 //! ```
 //!
-//! ## Custom validators
+//! # Custom validators
 //!
 //! In similar fashion it's possible to define custom validators, but a validation function receives a reference and returns `bool`.
 //! Think of it as a predicate.
@@ -236,11 +242,112 @@
 //! ```
 //!
 //!
-//! ## Feature flags
+//! # Feature flags
 //!
 //! * `serde1` - integrations with [`serde`](https://crates.io/crates/serde) crate. Allows to derive `Serialize` and `Deserialize` traits.
 //!
-//! ## Support Ukrainian military forces 🇺🇦
+//! # When nutype is a good fit for you?
+//!
+//! * If you enjoy [newtype](https://doc.rust-lang.org/book/ch19-04-advanced-types.html#using-the-newtype-pattern-for-type-safety-and-abstraction)
+//!   pattern and you like the idea of leveraging the Rust type system to enforce the correctness of the business logic.
+//! * If you're a DDD fan, nutype is a great helper to make your domain models even more expressive.
+//! * You want to prototype quickly without sacrificing quality.
+//!
+//! # When nutype is not that good?
+//!
+//! * You care too much about compiler time (nutype relies on heavy usage of proc macros).
+//! * You think metaprogramming is too much implicit magic.
+//! * IDEs may not be very helpful at giving you hints about proc macros.
+//! * Design of nutype may enforce you to run unnecessary validation (e.g. on loading data from DB), which may have a negative impact if you aim for extreme performance.
+//!
+//! # How it works?
+//!
+//!
+//! The following snippet
+//!
+//! ```rust
+//! #[nutype(
+//!     sanitize(trim, lowercase)
+//!     validate(present, max_len = 20)
+//! )]
+//! pub struct Username(String);
+//! ```
+//!
+//! eventually is transformed into something similar to this:
+//!
+//! ```rust
+//! // Everything is wrapped into the module,
+//! // so the internal tuple value of Username is private and cannot be directly manipulated.
+//! mod __nutype_private_Username__ {
+//!     pub struct Username(String);
+//!
+//!     pub enum UsernameError {
+//!         // Occurres when a string is not present
+//!         Missing,
+//!
+//!         // Occurres when a string is longer than 255 chars.
+//!         TooLong,
+//!     }
+//!
+//!     impl Username {
+//!         // The only legit way to construct Username.
+//!         // All other constructors (From, FromStr, Deserialize, etc.)
+//!         // are built on top of this one.
+//!         pub fn new(raw_username: impl Into<String>) -> Result<Username, UsernameError> {
+//!             // Sanitize
+//!             let sanitized_username = raw_username.into().trim().lowercase();
+//!
+//!             // Validate
+//!             if sanitized_username.empty() {
+//!                 Err(UsernameError::Missing)
+//!             } else if (sanitized_username.len() > 40 {
+//!                 Err(UsernameError::TooLong)
+//!             } else {
+//!                 Ok(Username(sanitized_username))
+//!             }
+//!         }
+//!
+//!         // Convert back to the inner type.
+//!         pub fn into_inner(self) -> String {
+//!             self.0
+//!         }
+//!     }
+//! }
+//!
+//! pub use __nutype_private_Username__::{Username, UsernameError};
+//! ```
+//!
+//! As you can see, `#[nutype]`  macro gets sanitization and validation rules and turns them into Rust code.
+//!
+//! The `Username::new()` constructor performs sanitization and validation and in case of success returns an instance of `Username`.
+//!
+//! The `Username::into_inner(self)` allows converting `Username` back into the inner type (`String`).
+//!
+//! And of course, the variants of `UsernameError` are derived from the validation rules.
+//!
+//! **But the whole point of the `nutype` crate is that there is no legit way to obtain an instance of `Username` that violates the sanitization or validation rules.**
+//! The author put a lot of effort into this. If you find a way to obtain the instance of a newtype bypassing the validation rules, please open an issue.
+//!
+//! # A note about #[derive(...)]
+//!
+//! You've got to know that the `#[nutype]` macro intercepts `#[derive(...)]` macro.
+//! It's done on purpose to ensure that anything like `DerefMut` or `BorrowMut`, that can lead to a violation of the validation rules is excluded.
+//! The library takes a conservative approach and it has its downside: deriving traits that are not known to the library is not possible.
+//!
+//! # Roadmap
+//!
+//! * [ ] refactor the parser logic
+//! * [ ] friendlier error messages:
+//!   * [ ] `did you mean ...?` hints
+//!   * [ ] intercept and explain why `DerefMut` and co cannot be derived
+//! * [ ] for floats: add `finite` validator and allow to derive `Eq` and `Ord`
+//! * [ ] integration with [diesel](https://github.com/diesel-rs/diesel)
+//! * [ ] integration with [sqlx](https://github.com/launchbadge/sqlx)
+//! * [ ] integration with [envconfig](https://github.com/greyblake/envconfig-rs)
+//! * [ ] integration with [arbitrary](https://github.com/rust-fuzz/arbitrary)
+//! * [ ] support `regex` to validate string types
+//!
+//! # Support Ukrainian military forces 🇺🇦
 //!
 //! Today I live in Berlin, I have the luxury to live a physically safe life.
 //! But I am Ukrainian. The first 25 years of my life I spent in [Kharkiv](https://en.wikipedia.org/wiki/Kharkiv),
@@ -255,6 +362,13 @@
 //! Your contribution to the Ukrainian military force is a contribution to my calmness, so I can spend more time developing the project.
 //!
 //! Thank you.
+//!
+//! # Similar projects
+//!
+//! * [bounded-integer](https://github.com/Kestrer/bounded-integer) - Bounded integers for Rust.
+//! * [refinement](https://docs.rs/refinement/latest/refinement/) - Convenient creation of type-safe refinement types (based on generics).
+//! * [semval](https://github.com/slowtec/semval) - Semantic validation for Rust.
+//! * [validator](https://github.com/Keats/validator) - Simple validation for Rust structs (powered by macros).
 
 pub use nutype_macros::nutype;
 


### PR DESCRIPTION
I know there's no issue for this; I totally understand if you'd rather not do this.

When I was working on #8, updating the doc in both places was a little annoying.
Also, in my experience it works better to generate the README from the crate top-level documentation, because it helps ensure that code samples work!

This PR:

- Uses `cargo readme` to generate the `README.md` from the doc comment.
- Fixes non-working code examples surfaced by this operation.
- Adds a workflow action to help ensure the readme is up to date with the doc comment going forward.

To do this, it:

- Introduces an implicit dependency on `cargo readme`
- Introduces a requirement to use `make build-readme` prior to releasing.

Note: This PR will cause merge conflicts with #8, if you're fine with both I'll of course resolve those conflicts in whichever is the second PR after whichever is the the first one is merged.