### PR TITLE
Add basic support to derive schemars::JsonSchema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           command: test
           args: --features new_unchecked
 
+      - name: cargo test --features schemars08
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features schemars08
+
       - name: cargo test --all-features
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * [BREAKING] Rename string validator `present` -> `not_empty`. Rename error variant `Missing` -> `Empty`.
 * Introduce `new_unchecked` feature flag, that allows to bypass sanitization and validation.
+* Support derive of `JsonSchema` of `schemars` crate (requires `schemars08` feature).
 
 ### v0.1.1 - 2023-02-11
 * Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,16 @@ name = "dummy"
 version = "0.1.0"
 dependencies = [
  "nutype",
+ "schemars",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "glob"
@@ -76,16 +83,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -105,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ name = "test_suite"
 version = "0.1.0"
 dependencies = [
  "nutype",
+ "schemars",
  "serde",
  "serde_json",
  "trybuild",

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ test:
 	cargo test
 	cargo test --features serde1
 	cargo test --features new_unchecked
+	cargo test --features schemars08
 	cargo test --all-features
 
 watch:

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ assert_eq!(name.into_inner(), " boo ");
 
 * `serde1` - integrations with [`serde`](https://crates.io/crates/serde) crate. Allows to derive `Serialize` and `Deserialize` traits.
 * `new_unchecked` - enables generation of unsafe `::new_unchecked()` function.
-* `schemars08` - allows to derive [`JsonSchema`](https://docs.rs/schemars/0.8.12/schemars/trait.JsonSchema.html) trait of [schemars](https://crates.io/crates/schemars) crate. Note that at the moment validation rules are not reflected in a derived json schema.
+* `schemars08` - allows to derive [`JsonSchema`](https://docs.rs/schemars/0.8.12/schemars/trait.JsonSchema.html) trait of [schemars](https://crates.io/crates/schemars) crate. Note that at the moment validation rules are not respected.
 
 ## When nutype is a good fit for you?
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ assert_eq!(name.into_inner(), " boo ");
 
 * `serde1` - integrations with [`serde`](https://crates.io/crates/serde) crate. Allows to derive `Serialize` and `Deserialize` traits.
 * `new_unchecked` - enables generation of unsafe `::new_unchecked()` function.
+* `schemars08` - allows to derive [`JsonSchema`](https://docs.rs/schemars/0.8.12/schemars/trait.JsonSchema.html) trait of [schemars](https://crates.io/crates/schemars) crate. Note that at the moment validation rules are not reflected in a derived json schema.
 
 ## When nutype is a good fit for you?
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,4 +1,7 @@
 ## Roadmap
+* JsonSchema: UI test
+* JsonSchema: add README, lib docs
+* In test_suite/Cargo.toml  pass `new_unchecked = ["nutype/new_unchecked"]`
 
 ### TODO Refactor:
 * Refactor parsers
@@ -113,3 +116,4 @@
 * Merge code examples in README and lib.rs into bigger chunks, so doc tests can run
 * Reuse gen_impl_into_inner
 * Refactor: Use newtype for errors (e.g. error_type_name, etc)
+* JsonSchema: Add unit tests

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,7 +1,8 @@
 ## Roadmap
-* JsonSchema: UI test
 * JsonSchema: add README, lib docs
-* In test_suite/Cargo.toml  pass `new_unchecked = ["nutype/new_unchecked"]`
+
+## Tech debt
+* Make individual UI tests possible to opt-out depending on the feature flags.
 
 ### TODO Refactor:
 * Refactor parsers
@@ -117,3 +118,4 @@
 * Reuse gen_impl_into_inner
 * Refactor: Use newtype for errors (e.g. error_type_name, etc)
 * JsonSchema: Add unit tests
+* JsonSchema: UI test

--- a/dummy/Cargo.toml
+++ b/dummy/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nutype = { path = "../nutype", features = ["serde1", "new_unchecked"] }
+nutype = { path = "../nutype", features = ["serde1", "new_unchecked", "schemars08"] }
 serde = "*"
 serde_json = "*"
+schemars = "*"

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,18 +1,18 @@
 use nutype::nutype;
 
 #[nutype(validate(max = 12.34))]
-#[derive(FromStr, Display, Clone, Copy, Serialize, Deserialize)]
+#[derive(FromStr, Display, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 pub struct Dist(f64);
 
 #[nutype(
     new_unchecked
     validate(min = 18, max = 99)
 )]
-#[derive(FromStr, Display, Clone, Copy, Serialize, Deserialize)]
+#[derive(FromStr, Display, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 pub struct Age(u8);
 
 #[nutype(new_unchecked)]
-#[derive(Debug, FromStr, Display, Clone, Serialize)]
+#[derive(Debug, FromStr, Display, Clone, Serialize, JsonSchema)]
 pub struct Username(String);
 
 fn main() {

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,4 +1,5 @@
 use nutype::nutype;
+use schemars::JsonSchema;
 
 #[nutype(validate(max = 12.34))]
 #[derive(FromStr, Display, Clone, Copy, Serialize, Deserialize, JsonSchema)]

--- a/nutype/Cargo.toml
+++ b/nutype/Cargo.toml
@@ -19,4 +19,5 @@ nutype_macros = { version = "0.2.0", path = "../nutype_macros" }
 
 [features]
 serde1 = ["nutype_macros/serde1"]
+schemars08 = ["nutype_macros/schemars08"]
 new_unchecked = ["nutype_macros/new_unchecked"]

--- a/nutype/src/lib.rs
+++ b/nutype/src/lib.rs
@@ -265,7 +265,7 @@
 //!
 //! * `serde1` - integrations with [`serde`](https://crates.io/crates/serde) crate. Allows to derive `Serialize` and `Deserialize` traits.
 //! * `new_unchecked` - enables generation of unsafe `::new_unchecked()` function.
-//! * `schemars08` - allows to derive [`JsonSchema`](https://docs.rs/schemars/0.8.12/schemars/trait.JsonSchema.html) trait of [schemars](https://crates.io/crates/schemars) crate. Note that at the moment validation rules are not reflected in a derived json schema.
+//! * `schemars08` - allows to derive [`JsonSchema`](https://docs.rs/schemars/0.8.12/schemars/trait.JsonSchema.html) trait of [schemars](https://crates.io/crates/schemars) crate. Note that at the moment validation rules are not respected.
 //!
 //! ## Support Ukrainian military forces 🇺🇦
 //!

--- a/nutype/src/lib.rs
+++ b/nutype/src/lib.rs
@@ -265,6 +265,7 @@
 //!
 //! * `serde1` - integrations with [`serde`](https://crates.io/crates/serde) crate. Allows to derive `Serialize` and `Deserialize` traits.
 //! * `new_unchecked` - enables generation of unsafe `::new_unchecked()` function.
+//! * `schemars08` - allows to derive [`JsonSchema`](https://docs.rs/schemars/0.8.12/schemars/trait.JsonSchema.html) trait of [schemars](https://crates.io/crates/schemars) crate. Note that at the moment validation rules are not reflected in a derived json schema.
 //!
 //! ## Support Ukrainian military forces 🇺🇦
 //!

--- a/nutype_macros/Cargo.toml
+++ b/nutype_macros/Cargo.toml
@@ -24,4 +24,5 @@ proc-macro = true
 
 [features]
 serde1 = []
+schemars08 = []
 new_unchecked = []

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -268,9 +268,11 @@ pub enum NormalDeriveTrait {
     //
     #[cfg_attr(not(feature = "serde1"), allow(dead_code))]
     SerdeSerialize,
-
     #[cfg_attr(not(feature = "serde1"), allow(dead_code))]
     SerdeDeserialize,
+
+    #[cfg_attr(not(feature = "schemars08"), allow(dead_code))]
+    SchemarsJsonSchema,
 }
 
 pub type SpannedDeriveTrait = SpannedItem<DeriveTrait>;

--- a/nutype_macros/src/common/parse/mod.rs
+++ b/nutype_macros/src/common/parse/mod.rs
@@ -334,6 +334,13 @@ fn parse_ident_into_derive_trait(ident: Ident) -> Result<SpannedDeriveTrait, syn
             #[cfg(feature = "serde1")]
             NormalDeriveTrait::SerdeDeserialize
         }
+        "JsonSchema" => {
+            #[cfg(not(feature = "schemars08"))]
+            return Err(syn::Error::new(ident.span(), "To derive JsonSchema, the feature `schemars08` of the crate `nutype` needs to be enabled."));
+
+            #[cfg(feature = "schemars08")]
+            NormalDeriveTrait::SchemarsJsonSchema
+        }
         _ => {
             return Err(syn::Error::new(
                 ident.span(),

--- a/nutype_macros/src/float/gen/traits.rs
+++ b/nutype_macros/src/float/gen/traits.rs
@@ -16,6 +16,7 @@ use crate::{
 
 type FloatGeneratableTrait = GeneratableTrait<FloatStandardTrait, FloatIrregularTrait>;
 
+// TODO: Consider renaming Standard -> Proxy ?
 /// A trait that can be automatically derived.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 enum FloatStandardTrait {
@@ -24,6 +25,7 @@ enum FloatStandardTrait {
     Copy,
     PartialEq,
     PartialOrd,
+    SchemarsJsonSchema,
 }
 
 /// A trait that can not be automatically derived and we need to generate
@@ -74,6 +76,9 @@ impl From<FloatDeriveTrait> for FloatGeneratableTrait {
             FloatDeriveTrait::SerdeDeserialize => {
                 FloatGeneratableTrait::Irregular(FloatIrregularTrait::SerdeDeserialize)
             }
+            FloatDeriveTrait::SchemarsJsonSchema => {
+                FloatGeneratableTrait::Standard(FloatStandardTrait::SchemarsJsonSchema)
+            }
         }
     }
 }
@@ -86,6 +91,7 @@ impl ToTokens for FloatStandardTrait {
             Self::Copy => quote!(Copy),
             Self::PartialEq => quote!(PartialEq),
             Self::PartialOrd => quote!(PartialOrd),
+            Self::SchemarsJsonSchema => quote!(::schemars::JsonSchema),
         };
         tokens.to_tokens(token_stream)
     }

--- a/nutype_macros/src/float/models.rs
+++ b/nutype_macros/src/float/models.rs
@@ -104,6 +104,7 @@ pub enum FloatDeriveTrait {
     // External crates
     SerdeSerialize,
     SerdeDeserialize,
+    SchemarsJsonSchema,
     // Arbitrary,
 }
 

--- a/nutype_macros/src/float/validate.rs
+++ b/nutype_macros/src/float/validate.rs
@@ -171,5 +171,6 @@ fn to_float_derive_trait(
         }
         NormalDeriveTrait::SerdeSerialize => Ok(FloatDeriveTrait::SerdeSerialize),
         NormalDeriveTrait::SerdeDeserialize => Ok(FloatDeriveTrait::SerdeDeserialize),
+        NormalDeriveTrait::SchemarsJsonSchema => Ok(FloatDeriveTrait::SchemarsJsonSchema),
     }
 }

--- a/nutype_macros/src/integer/gen/traits.rs
+++ b/nutype_macros/src/integer/gen/traits.rs
@@ -99,6 +99,9 @@ impl From<IntegerDeriveTrait> for IntegerGeneratableTrait {
             IntegerDeriveTrait::SerdeDeserialize => {
                 IntegerGeneratableTrait::Irregular(IntegerIrregularTrait::SerdeDeserialize)
             }
+            IntegerDeriveTrait::SchemarsJsonSchema => {
+                IntegerGeneratableTrait::Standard(IntegerStandardTrait::SchemarsJsonSchema)
+            }
         }
     }
 }
@@ -114,6 +117,7 @@ enum IntegerStandardTrait {
     PartialOrd,
     Ord,
     Hash,
+    SchemarsJsonSchema,
 }
 
 /// A trait that can not be automatically derived and we need to generate
@@ -142,6 +146,7 @@ impl ToTokens for IntegerStandardTrait {
             Self::PartialOrd => quote!(PartialOrd),
             Self::Ord => quote!(Ord),
             Self::Hash => quote!(Hash),
+            Self::SchemarsJsonSchema => quote!(::schemars::JsonSchema),
         };
         tokens.to_tokens(token_stream)
     }

--- a/nutype_macros/src/integer/models.rs
+++ b/nutype_macros/src/integer/models.rs
@@ -107,6 +107,7 @@ pub enum IntegerDeriveTrait {
     // // External crates
     SerdeSerialize,
     SerdeDeserialize,
+    SchemarsJsonSchema,
     // Arbitrary,
 }
 

--- a/nutype_macros/src/integer/validate.rs
+++ b/nutype_macros/src/integer/validate.rs
@@ -151,6 +151,7 @@ fn to_integer_derive_trait(
         NormalDeriveTrait::Copy => Ok(IntegerDeriveTrait::Copy),
         NormalDeriveTrait::SerdeSerialize => Ok(IntegerDeriveTrait::SerdeSerialize),
         NormalDeriveTrait::SerdeDeserialize => Ok(IntegerDeriveTrait::SerdeDeserialize),
+        NormalDeriveTrait::SchemarsJsonSchema => Ok(IntegerDeriveTrait::SchemarsJsonSchema),
         NormalDeriveTrait::From => {
             if has_validation {
                 Err(syn::Error::new(span, "#[nutype] cannot derive `From` trait, because there is validation defined. Use `TryFrom` instead."))

--- a/nutype_macros/src/string/gen/traits.rs
+++ b/nutype_macros/src/string/gen/traits.rs
@@ -28,6 +28,7 @@ enum StringStandardTrait {
     PartialOrd,
     Ord,
     Hash,
+    SchemarsJsonSchema,
 }
 
 /// A trait that can not be automatically derived and we need to generate
@@ -90,6 +91,9 @@ impl From<StringDeriveTrait> for StringGeneratableTrait {
             StringDeriveTrait::SerdeDeserialize => {
                 StringGeneratableTrait::Irregular(StringIrregularTrait::SerdeDeserialize)
             }
+            StringDeriveTrait::SchemarsJsonSchema => {
+                StringGeneratableTrait::Standard(StringStandardTrait::SchemarsJsonSchema)
+            }
         }
     }
 }
@@ -104,6 +108,7 @@ impl ToTokens for StringStandardTrait {
             Self::PartialOrd => quote!(PartialOrd),
             Self::Ord => quote!(Ord),
             Self::Hash => quote!(Hash),
+            Self::SchemarsJsonSchema => quote!(::schemars::JsonSchema),
         };
         tokens.to_tokens(token_stream)
     }

--- a/nutype_macros/src/string/models.rs
+++ b/nutype_macros/src/string/models.rs
@@ -117,6 +117,7 @@ pub enum StringDeriveTrait {
     //
     SerdeSerialize,
     SerdeDeserialize,
+    SchemarsJsonSchema,
     // Arbitrary,
 }
 

--- a/nutype_macros/src/string/validate.rs
+++ b/nutype_macros/src/string/validate.rs
@@ -158,6 +158,7 @@ fn to_string_derive_trait(
         NormalDeriveTrait::Into => Ok(StringDeriveTrait::Into),
         NormalDeriveTrait::SerdeSerialize => Ok(StringDeriveTrait::SerdeSerialize),
         NormalDeriveTrait::SerdeDeserialize => Ok(StringDeriveTrait::SerdeDeserialize),
+        NormalDeriveTrait::SchemarsJsonSchema => Ok(StringDeriveTrait::SchemarsJsonSchema),
         NormalDeriveTrait::Copy => Err(syn::Error::new(
             span,
             "Copy trait cannot be derived for a String based type",

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -11,8 +11,10 @@ trybuild = { version = "1.0.71", features = ["diff"] }
 
 serde = { version = "1.0.150", optional = true }
 serde_json = { version = "1.0.89", optional = true }
+schemars = { version = "0.8", optional = true }
 
 [features]
 serde1 = ["nutype/serde1", "serde", "serde_json"]
-ui = []
+schemars08 = ["nutype/schemars08", "schemars"]
 new_unchecked = []
+ui = []

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -15,6 +15,6 @@ schemars = { version = "0.8", optional = true }
 
 [features]
 serde1 = ["nutype/serde1", "serde", "serde_json"]
-schemars08 = ["nutype/schemars08", "schemars"]
+schemars08 = ["schemars"]
 new_unchecked = []
 ui = []

--- a/test_suite/tests/float.rs
+++ b/test_suite/tests/float.rs
@@ -428,3 +428,21 @@ mod new_unchecked {
         assert_eq!(dist.into_inner(), 3.0);
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "schemars08")]
+mod derive_schemars_json_schema {
+    use super::*;
+    use schemars::{schema_for, JsonSchema};
+
+    #[test]
+    fn test_json_schema_derive() {
+        #[nutype]
+        #[derive(JsonSchema)]
+        pub struct ProductWeight(f64);
+
+        assert_eq!(ProductWeight::schema_name(), "ProductWeight");
+        // Make sure it compiles
+        let _schema = schema_for!(ProductWeight);
+    }
+}

--- a/test_suite/tests/integer.rs
+++ b/test_suite/tests/integer.rs
@@ -571,3 +571,21 @@ mod new_unchecked {
         assert_eq!(dist.into_inner(), 3);
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "schemars08")]
+mod derive_schemars_json_schema {
+    use super::*;
+    use schemars::{schema_for, JsonSchema};
+
+    #[test]
+    fn test_json_schema_derive() {
+        #[nutype]
+        #[derive(JsonSchema)]
+        pub struct CustomerId(i128);
+
+        assert_eq!(CustomerId::schema_name(), "CustomerId");
+        // Make sure it compiles
+        let _schema = schema_for!(CustomerId);
+    }
+}

--- a/test_suite/tests/string.rs
+++ b/test_suite/tests/string.rs
@@ -453,3 +453,21 @@ mod new_unchecked {
         assert_eq!(name.into_inner(), " boo ");
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "schemars08")]
+mod derive_schemars_json_schema {
+    use super::*;
+    use schemars::{schema_for, JsonSchema};
+
+    #[test]
+    fn test_json_schema_derive() {
+        #[nutype]
+        #[derive(JsonSchema)]
+        pub struct CustomerIdentifier(String);
+
+        assert_eq!(CustomerIdentifier::schema_name(), "CustomerIdentifier");
+        // Make sure it compiles
+        let _schema = schema_for!(CustomerIdentifier);
+    }
+}

--- a/test_suite/tests/ui/common/schemars08.rs
+++ b/test_suite/tests/ui/common/schemars08.rs
@@ -1,0 +1,7 @@
+use nutype::nutype;
+
+#[nutype]
+#[derive(JsonSchema)]
+pub struct Username(String);
+
+fn main() {}

--- a/test_suite/tests/ui/common/schemars08.stderr
+++ b/test_suite/tests/ui/common/schemars08.stderr
@@ -1,0 +1,5 @@
+error: To derive JsonSchema, the feature `schemars08` of the crate `nutype` needs to be enabled.
+ --> tests/ui/common/schemars08.rs:4:10
+  |
+4 | #[derive(JsonSchema)]
+  |          ^^^^^^^^^^


### PR DESCRIPTION
It addresses #12 

## Changes
* Add `schemars08` feature flag
* Support derive of `JsonSchema` for integers, floats and strings
