### PR TITLE
Default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,30 +19,30 @@ jobs:
         with:
           toolchain: stable
 
-      - name: cargo test
+      - name: cargo test --features nutype_test
         uses: actions-rs/cargo@v1
         with:
           command: test
 
-      - name: cargo test --features serde
+      - name: cargo test --features nutype_test,serde
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --features serde
 
-      - name: cargo test --features regex
+      - name: cargo test --features nutype_test,regex
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --features regex
 
-      - name: cargo test --features new_unchecked
+      - name: cargo test --features nutype_test,new_unchecked
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --features new_unchecked
 
-      - name: cargo test --features schemars08
+      - name: cargo test --features nutype_test,schemars08
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### v0.3.0 - 2023-??-??
 * [BREAKING] `min_len` and `max_len` validators run against number of characters in a string (`val.chars().count()`), not number of bytes (`val.len()`).
 * Add `finite` validation for float types which checks against NaN and infinity.
-* Enable deriving of `Eq` and `Ord` on float types (if `finite` validation is present)
-* Enable deriving of `TryFrom` for types without validation (in this case Error type is `std::convert::Infallible`)
+* Support deriving of `Default`
+* Support deriving of `Eq` and `Ord` on float types (if `finite` validation is present)
+* Support deriving of `TryFrom` for types without validation (in this case Error type is `std::convert::Infallible`)
 
 ### v0.2.0 - 2023-04-13
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 test: clippy
-	cargo test
-	cargo test --features serde
-	cargo test --features regex
-	cargo test --features new_unchecked
-	cargo test --features schemars08
+	cargo test --features nutype_test
+	cargo test --features nutype_test,serde
+	cargo test --features nutype_test,regex
+	cargo test --features nutype_test,new_unchecked
+	cargo test --features nutype_test,schemars08
 	cargo test --all-features
 
 watch:

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ pub struct PhoneNumber(String);
 ### String derivable traits
 
 The following traits can be derived for a string-based type:
-`Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `From`, `TryFrom`, `Into`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
+`Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `From`, `TryFrom`, `Into`, `Hash`, `Borrow`, `Display`, `Default`, `Serialize`, `Deserialize`.
 
 
 ## Integer
@@ -204,7 +204,7 @@ The integer inner types are: `u8`, `u16`,`u32`, `u64`, `u128`, `i8`, `i16`, `i32
 ### Integer derivable traits
 
 The following traits can be derived for an integer-based type:
-`Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
+`Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Default`, `Serialize`, `Deserialize`.
 
 
 ## Float
@@ -229,7 +229,7 @@ The float inner types are: `f32`, `f64`.
 ### Float derivable traits
 
 The following traits can be derived for a float-based type:
-`Debug`, `Clone`, `Copy`, `PartialEq`, `PartialOrd`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
+`Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Default`, `Serialize`, `Deserialize`.
 
 It's also possible to derive `Eq` and `Ord` if the validation rules guarantee that `NaN` is excluded.
 This can be done applying by `finite` validation. For example:
@@ -284,6 +284,28 @@ fn is_valid_name(name: &str) -> bool {
     name.chars().next().map(char::is_uppercase).unwrap_or(false)
 }
 ```
+
+## Deriving recipes
+
+### Deriving `Default`
+
+```rs
+#[nutype(default = "Anonymous")]
+#[derive(Default)]
+pub struct Name(String);
+```
+
+### Deriving `Eq` and `Ord` on float types
+
+With nutype it's possible to derive `Eq` and `Ord` if there is `finite` validation set.
+The `finite` validation ensures that the valid value excludes `NaN`.
+
+```rs
+#[nutype(validate(finite))]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct Weight(f64);
+```
+
 
 ## How to break the constraints?
 

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -4,5 +4,4 @@ use nutype::nutype;
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct Weight(f64);
 
-fn main() {
-}
+fn main() {}

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,13 +1,8 @@
 use nutype::nutype;
 
-#[nutype(
-    validate(max_len = 6)
-    default = "FooBar"
-)]
-#[derive(Debug, Display, Default)]
-pub struct Name(String);
+#[nutype(validate(finite))]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub struct Weight(f64);
 
 fn main() {
-    let name = Name::default();
-    println!("name = {name}");
 }

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,6 +1,13 @@
 use nutype::nutype;
 
-#[nutype(validate(min_len = 3, max_len = 255))]
+#[nutype(
+    validate(max_len = 6)
+    default = "FooBar"
+)]
+#[derive(Debug, Display, Default)]
 pub struct Name(String);
 
-fn main() {}
+fn main() {
+    let name = Name::default();
+    println!("name = {name}");
+}

--- a/nutype/src/lib.rs
+++ b/nutype/src/lib.rs
@@ -177,7 +177,7 @@
 //! ### String derivable traits
 //!
 //! The following traits can be derived for a string-based type:
-//! `Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `From`, `TryFrom`, `Into`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
+//! `Debug`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `From`, `TryFrom`, `Into`, `Hash`, `Borrow`, `Display`, `Default`, `Serialize`, `Deserialize`.
 //!
 //!
 //! ## Integer
@@ -201,7 +201,7 @@
 //! ### Integer derivable traits
 //!
 //! The following traits can be derived for an integer-based type:
-//! `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
+//! `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Default`, `Serialize`, `Deserialize`.
 //!
 //!
 //! ## Float
@@ -226,7 +226,7 @@
 //! ### Float derivable traits
 //!
 //! The following traits can be derived for a float-based type:
-//! `Debug`, `Clone`, `Copy`, `PartialEq`, `PartialOrd`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Serialize`, `Deserialize`.
+//! `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `FromStr`, `AsRef`, `Into`, `From`, `TryFrom`, `Hash`, `Borrow`, `Display`, `Default`, `Serialize`, `Deserialize`.
 //!
 //! It's also possible to derive `Eq` and `Ord` if the validation rules guarantee that `NaN` is excluded.
 //! This can be done by applying `finite` validation. For example:
@@ -285,6 +285,30 @@
 //!     // A fancy way to verify if the first character is uppercase
 //!     name.chars().next().map(char::is_uppercase).unwrap_or(false)
 //! }
+//! ```
+//! ## Deriving recipes
+//!
+//! ### Deriving `Default`
+//!
+//! ```
+//! use nutype::nutype;
+//!
+//! #[nutype(default = "Anonymous")]
+//! #[derive(Default)]
+//! pub struct Name(String);
+//! ```
+//!
+//! ### Deriving `Eq` and `Ord` on float types
+//!
+//! With nutype it's possible to derive `Eq` and `Ord` if there is `finite` validation set.
+//! The `finite` validation ensures that the valid value excludes `NaN`.
+//!
+//! ```
+//! use nutype::nutype;
+//!
+//! #[nutype(validate(finite))]
+//! #[derive(PartialEq, Eq, PartialOrd, Ord)]
+//! pub struct Weight(f64);
 //! ```
 //!
 //! ## How to break the constraints?

--- a/nutype_macros/Cargo.toml
+++ b/nutype_macros/Cargo.toml
@@ -30,3 +30,8 @@ proc-macro = true
 serde = []
 schemars08 = []
 new_unchecked = []
+
+# nutype_test is set when unit tests for nutype is running.
+# Why: we don't want to generate unit tests when we're already within a unit test, because it results
+# into warnings.
+nutype_test = []

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -253,13 +253,21 @@ pub fn gen_impl_trait_default(
     // satisfy the validation rules.
     // For this purpose we generate a unit test to verify this at run time.
     let unit_test = if has_validation {
-        quote!(
-            #[test]
-            fn should_have_valid_default_value() {
-                let default_inner_value = #type_name::default().into_inner();
-                #type_name::new(default_inner_value).expect("Default value must be valid");
-            }
-        )
+        #[cfg(not(feature = "nutype_test"))]
+        {
+            quote!(
+                #[test]
+                fn should_have_valid_default_value() {
+                    let default_inner_value = #type_name::default().into_inner();
+                    #type_name::new(default_inner_value).expect("Default value must be valid");
+                }
+            )
+        }
+
+        #[cfg(feature = "nutype_test")]
+        {
+            quote!()
+        }
     } else {
         quote!()
     };

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -192,6 +192,9 @@ pub struct Attributes<G> {
 
     /// `new_unchecked` flag
     pub new_unchecked: NewUnchecked,
+
+    /// Value for Default trait. Provide with `default = `
+    pub maybe_default_value: Option<TokenStream>,
 }
 
 impl<Sanitizer, Validator> Guard<Sanitizer, Validator> {
@@ -234,6 +237,7 @@ pub enum NormalDeriveTrait {
     Hash,
     Borrow,
     Display,
+    Default,
 
     // External crates
     //

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -30,6 +30,7 @@ pub fn gen_nutype_for_float<T>(
     meta: FloatGuard<T>,
     traits: HashSet<FloatDeriveTrait>,
     new_unchecked: NewUnchecked,
+    maybe_default_value: Option<TokenStream>,
 ) -> TokenStream
 where
     T: ToTokens + PartialOrd,
@@ -59,7 +60,13 @@ where
     let GeneratedTraits {
         derive_transparent_traits,
         implement_traits,
-    } = gen_traits(type_name, inner_type, maybe_error_type_name, traits);
+    } = gen_traits(
+        type_name,
+        inner_type,
+        maybe_error_type_name,
+        maybe_default_value,
+        traits,
+    );
 
     quote!(
         #[doc(hidden)]

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -22,6 +22,9 @@ use crate::{
 };
 use traits::gen_traits;
 
+// TODO: These are too many arguments indeed.
+// Consider refactoring.
+#[allow(clippy::too_many_arguments)]
 pub fn gen_nutype_for_float<T>(
     doc_attrs: Vec<syn::Attribute>,
     vis: Visibility,

--- a/nutype_macros/src/float/gen/traits.rs
+++ b/nutype_macros/src/float/gen/traits.rs
@@ -10,7 +10,10 @@ use crate::{
         gen_impl_trait_serde_serialize, gen_impl_trait_try_from, split_into_generatable_traits,
         GeneratableTrait, GeneratableTraits, GeneratedTraits,
     },
-    common::models::{ErrorTypeName, FloatInnerType, TypeName},
+    common::{
+        gen::traits::gen_impl_trait_default,
+        models::{ErrorTypeName, FloatInnerType, TypeName},
+    },
     float::models::FloatDeriveTrait,
 };
 
@@ -40,6 +43,7 @@ enum FloatIrregularTrait {
     TryFrom,
     Borrow,
     Display,
+    Default,
     SerdeSerialize,
     SerdeDeserialize,
 }
@@ -79,6 +83,9 @@ impl From<FloatDeriveTrait> for FloatGeneratableTrait {
             FloatDeriveTrait::Display => {
                 FloatGeneratableTrait::Irregular(FloatIrregularTrait::Display)
             }
+            FloatDeriveTrait::Default => {
+                FloatGeneratableTrait::Irregular(FloatIrregularTrait::Default)
+            }
             FloatDeriveTrait::SerdeSerialize => {
                 FloatGeneratableTrait::Irregular(FloatIrregularTrait::SerdeSerialize)
             }
@@ -110,6 +117,7 @@ pub fn gen_traits(
     type_name: &TypeName,
     inner_type: FloatInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
+    maybe_default_value: Option<TokenStream>,
     traits: HashSet<FloatDeriveTrait>,
 ) -> GeneratedTraits {
     let GeneratableTraits {
@@ -127,6 +135,7 @@ pub fn gen_traits(
         type_name,
         inner_type,
         maybe_error_type_name,
+        maybe_default_value,
         irregular_traits,
     );
 
@@ -140,6 +149,7 @@ fn gen_implemented_traits(
     type_name: &TypeName,
     inner_type: FloatInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
+    maybe_default_value: Option<TokenStream>,
     impl_traits: Vec<FloatIrregularTrait>,
 ) -> TokenStream {
     impl_traits
@@ -156,6 +166,17 @@ fn gen_implemented_traits(
             }
             FloatIrregularTrait::Borrow => gen_impl_trait_borrow(type_name, inner_type),
             FloatIrregularTrait::Display => gen_impl_trait_dislpay(type_name),
+            FloatIrregularTrait::Default => {
+                match maybe_default_value {
+                    Some(ref default_value) => {
+                        let has_validation = maybe_error_type_name.is_some();
+                        gen_impl_trait_default(type_name, &default_value, has_validation)
+                    },
+                    None => {
+                        panic!("Default trait is derived for type {type_name}, but `default = ` is missing");
+                    }
+                }
+            }
             FloatIrregularTrait::SerdeSerialize => gen_impl_trait_serde_serialize(type_name),
             FloatIrregularTrait::SerdeDeserialize => gen_impl_trait_serde_deserialize(
                 type_name,

--- a/nutype_macros/src/float/gen/traits.rs
+++ b/nutype_macros/src/float/gen/traits.rs
@@ -170,7 +170,7 @@ fn gen_implemented_traits(
                 match maybe_default_value {
                     Some(ref default_value) => {
                         let has_validation = maybe_error_type_name.is_some();
-                        gen_impl_trait_default(type_name, &default_value, has_validation)
+                        gen_impl_trait_default(type_name, default_value, has_validation)
                     },
                     None => {
                         panic!("Default trait is derived for type {type_name}, but `default = ` is missing");

--- a/nutype_macros/src/float/models.rs
+++ b/nutype_macros/src/float/models.rs
@@ -106,6 +106,7 @@ pub enum FloatDeriveTrait {
     TryFrom,
     Borrow,
     Display,
+    Default,
 
     // External crates
     SerdeSerialize,

--- a/nutype_macros/src/float/parse.rs
+++ b/nutype_macros/src/float/parse.rs
@@ -27,11 +27,13 @@ where
     let Attributes {
         new_unchecked,
         guard: raw_guard,
+        maybe_default_value,
     } = raw_attrs;
     let guard = validate_number_meta(raw_guard)?;
     Ok(Attributes {
         new_unchecked,
         guard,
+        maybe_default_value,
     })
 }
 

--- a/nutype_macros/src/float/validate.rs
+++ b/nutype_macros/src/float/validate.rs
@@ -206,6 +206,7 @@ fn to_float_derive_trait(
     match tr {
         NormalDeriveTrait::Debug => Ok(FloatDeriveTrait::Debug),
         NormalDeriveTrait::Display => Ok(FloatDeriveTrait::Display),
+        NormalDeriveTrait::Default => Ok(FloatDeriveTrait::Default),
         NormalDeriveTrait::Clone => Ok(FloatDeriveTrait::Clone),
         NormalDeriveTrait::PartialEq => Ok(FloatDeriveTrait::PartialEq),
         NormalDeriveTrait::Into => Ok(FloatDeriveTrait::Into),

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -29,6 +29,7 @@ pub fn gen_nutype_for_integer<T>(
     meta: IntegerGuard<T>,
     traits: HashSet<IntegerDeriveTrait>,
     new_unchecked: NewUnchecked,
+    maybe_default_value: Option<TokenStream>,
 ) -> TokenStream
 where
     T: ToTokens + PartialOrd,
@@ -58,7 +59,13 @@ where
     let GeneratedTraits {
         derive_transparent_traits,
         implement_traits,
-    } = gen_traits(type_name, inner_type, maybe_error_type_name, traits);
+    } = gen_traits(
+        type_name,
+        inner_type,
+        maybe_error_type_name,
+        traits,
+        maybe_default_value,
+    );
 
     quote!(
         #[doc(hidden)]

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -21,6 +21,9 @@ use crate::{
     },
 };
 
+// TODO: These are too many arguments indeed.
+// Consider refactoring.
+#[allow(clippy::too_many_arguments)]
 pub fn gen_nutype_for_integer<T>(
     doc_attrs: Vec<syn::Attribute>,
     vis: Visibility,

--- a/nutype_macros/src/integer/gen/traits.rs
+++ b/nutype_macros/src/integer/gen/traits.rs
@@ -187,7 +187,7 @@ fn gen_implemented_traits(
                 match maybe_default_value {
                     Some(ref default_value) => {
                         let has_validation = maybe_error_type_name.is_some();
-                        gen_impl_trait_default(type_name, &default_value, has_validation)
+                        gen_impl_trait_default(type_name, default_value, has_validation)
                     },
                     None => {
                         panic!("Default trait is derived for type {type_name}, but `default = ` parameter is missing in #[nutype] macro");

--- a/nutype_macros/src/integer/models.rs
+++ b/nutype_macros/src/integer/models.rs
@@ -103,6 +103,7 @@ pub enum IntegerDeriveTrait {
     Hash,
     Borrow,
     Display,
+    Default,
 
     // // External crates
     SerdeSerialize,

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -27,11 +27,13 @@ where
     let Attributes {
         new_unchecked,
         guard: raw_guard,
+        maybe_default_value,
     } = raw_attrs;
     let guard = validate_number_meta(raw_guard)?;
     Ok(Attributes {
         new_unchecked,
         guard,
+        maybe_default_value,
     })
 }
 

--- a/nutype_macros/src/integer/validate.rs
+++ b/nutype_macros/src/integer/validate.rs
@@ -138,6 +138,7 @@ fn to_integer_derive_trait(
     match tr {
         NormalDeriveTrait::Debug => Ok(IntegerDeriveTrait::Debug),
         NormalDeriveTrait::Display => Ok(IntegerDeriveTrait::Display),
+        NormalDeriveTrait::Default => Ok(IntegerDeriveTrait::Default),
         NormalDeriveTrait::Clone => Ok(IntegerDeriveTrait::Clone),
         NormalDeriveTrait::PartialEq => Ok(IntegerDeriveTrait::PartialEq),
         NormalDeriveTrait::Eq => Ok(IntegerDeriveTrait::Eq),

--- a/nutype_macros/src/lib.rs
+++ b/nutype_macros/src/lib.rs
@@ -43,6 +43,7 @@ fn expand_nutype(
             let Attributes {
                 guard,
                 new_unchecked,
+                maybe_default_value,
             } = string::parse::parse_attributes(attrs)?;
             let traits = validate_string_derive_traits(&guard, derive_traits)?;
             Ok(gen_nutype_for_string(
@@ -52,6 +53,7 @@ fn expand_nutype(
                 &type_name,
                 guard,
                 new_unchecked,
+                maybe_default_value,
             ))
         }
         InnerType::Integer(tp) => {
@@ -122,6 +124,7 @@ where
     let Attributes {
         guard,
         new_unchecked,
+        maybe_default_value,
     } = integer::parse::parse_attributes::<T>(attrs)?;
     let traits = validate_integer_derive_traits(derive_traits, guard.has_validation())?;
     Ok(integer::gen::gen_nutype_for_integer(
@@ -132,6 +135,7 @@ where
         guard,
         traits,
         new_unchecked,
+        maybe_default_value,
     ))
 }
 
@@ -153,6 +157,7 @@ where
     let Attributes {
         guard,
         new_unchecked,
+        maybe_default_value,
     } = float::parse::parse_attributes::<T>(attrs)?;
     let traits = validate_float_derive_traits(derive_traits, &guard)?;
     Ok(float::gen::gen_nutype_for_float(
@@ -163,5 +168,6 @@ where
         guard,
         traits,
         new_unchecked,
+        maybe_default_value,
     ))
 }

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -30,6 +30,7 @@ pub fn gen_nutype_for_string(
     type_name: &TypeName,
     guard: StringGuard,
     new_unchecked: NewUnchecked,
+    maybe_default_value: Option<TokenStream>,
 ) -> TokenStream {
     let module_name = gen_module_name_for_type(type_name);
     let implementation = gen_string_implementation(type_name, &guard, new_unchecked);
@@ -50,7 +51,12 @@ pub fn gen_nutype_for_string(
     let GeneratedTraits {
         derive_transparent_traits,
         implement_traits,
-    } = gen_traits(type_name, maybe_error_type_name, traits);
+    } = gen_traits(
+        type_name,
+        maybe_error_type_name,
+        maybe_default_value,
+        traits,
+    );
 
     quote!(
         #[doc(hidden)]

--- a/nutype_macros/src/string/gen/traits.rs
+++ b/nutype_macros/src/string/gen/traits.rs
@@ -181,7 +181,7 @@ fn gen_implemented_traits(
                 match maybe_default_value {
                     Some(ref default_value) => {
                         let has_validation = maybe_error_type_name.is_some();
-                        gen_impl_trait_default(type_name, &default_value, has_validation)
+                        gen_impl_trait_default(type_name, default_value, has_validation)
                     }
                     None => {
                         panic!("Default trait is derived for type {type_name}, but `default = ` is missing");

--- a/nutype_macros/src/string/gen/traits.rs
+++ b/nutype_macros/src/string/gen/traits.rs
@@ -6,10 +6,11 @@ use quote::{quote, ToTokens};
 use crate::{
     common::{
         gen::traits::{
-            gen_impl_trait_as_ref, gen_impl_trait_borrow, gen_impl_trait_dislpay,
-            gen_impl_trait_from, gen_impl_trait_into, gen_impl_trait_serde_deserialize,
-            gen_impl_trait_serde_serialize, gen_impl_trait_try_from, split_into_generatable_traits,
-            GeneratableTrait, GeneratableTraits, GeneratedTraits,
+            gen_impl_trait_as_ref, gen_impl_trait_borrow, gen_impl_trait_default,
+            gen_impl_trait_dislpay, gen_impl_trait_from, gen_impl_trait_into,
+            gen_impl_trait_serde_deserialize, gen_impl_trait_serde_serialize,
+            gen_impl_trait_try_from, split_into_generatable_traits, GeneratableTrait,
+            GeneratableTraits, GeneratedTraits,
         },
         models::{ErrorTypeName, InnerType, TypeName},
     },
@@ -42,6 +43,7 @@ enum StringIrregularTrait {
     TryFrom,
     Borrow,
     Display,
+    Default,
     SerdeSerialize,
     SerdeDeserialize,
 }
@@ -91,6 +93,9 @@ impl From<StringDeriveTrait> for StringGeneratableTrait {
             StringDeriveTrait::Display => {
                 StringGeneratableTrait::Irregular(StringIrregularTrait::Display)
             }
+            StringDeriveTrait::Default => {
+                StringGeneratableTrait::Irregular(StringIrregularTrait::Default)
+            }
             StringDeriveTrait::SerdeSerialize => {
                 StringGeneratableTrait::Irregular(StringIrregularTrait::SerdeSerialize)
             }
@@ -123,6 +128,7 @@ impl ToTokens for StringTransparentTrait {
 pub fn gen_traits(
     type_name: &TypeName,
     maybe_error_type_name: Option<ErrorTypeName>,
+    maybe_default_value: Option<TokenStream>,
     traits: HashSet<StringDeriveTrait>,
 ) -> GeneratedTraits {
     let GeneratableTraits {
@@ -136,8 +142,12 @@ pub fn gen_traits(
         )]
     };
 
-    let implement_traits =
-        gen_implemented_traits(type_name, maybe_error_type_name, irregular_traits);
+    let implement_traits = gen_implemented_traits(
+        type_name,
+        maybe_error_type_name,
+        maybe_default_value,
+        irregular_traits,
+    );
 
     GeneratedTraits {
         derive_transparent_traits,
@@ -148,6 +158,7 @@ pub fn gen_traits(
 fn gen_implemented_traits(
     type_name: &TypeName,
     maybe_error_type_name: Option<ErrorTypeName>,
+    maybe_default_value: Option<TokenStream>,
     impl_traits: Vec<StringIrregularTrait>,
 ) -> TokenStream {
     let inner_type = InnerType::String;
@@ -166,6 +177,17 @@ fn gen_implemented_traits(
             }
             StringIrregularTrait::Borrow => gen_impl_borrow_str_and_string(type_name),
             StringIrregularTrait::Display => gen_impl_trait_dislpay(type_name),
+            StringIrregularTrait::Default => {
+                match maybe_default_value {
+                    Some(ref default_value) => {
+                        let has_validation = maybe_error_type_name.is_some();
+                        gen_impl_trait_default(type_name, &default_value, has_validation)
+                    }
+                    None => {
+                        panic!("Default trait is derived for type {type_name}, but `default = ` is missing");
+                    }
+                }
+            }
             StringIrregularTrait::SerdeSerialize => gen_impl_trait_serde_serialize(type_name),
             StringIrregularTrait::SerdeDeserialize => gen_impl_trait_serde_deserialize(
                 type_name,

--- a/nutype_macros/src/string/models.rs
+++ b/nutype_macros/src/string/models.rs
@@ -130,6 +130,8 @@ pub enum StringDeriveTrait {
     Hash,
     Borrow,
     Display,
+    Default,
+
     // // External crates
     //
     SerdeSerialize,

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -16,11 +16,13 @@ pub fn parse_attributes(input: TokenStream) -> Result<Attributes<StringGuard>, s
     let Attributes {
         new_unchecked,
         guard: raw_guard,
+        maybe_default_value,
     } = raw_attrs;
     let guard = validate_string_meta(raw_guard)?;
     Ok(Attributes {
         new_unchecked,
         guard,
+        maybe_default_value,
     })
 }
 

--- a/nutype_macros/src/string/validate.rs
+++ b/nutype_macros/src/string/validate.rs
@@ -157,6 +157,7 @@ fn to_string_derive_trait(
     match tr {
         NormalDeriveTrait::Debug => Ok(StringDeriveTrait::Debug),
         NormalDeriveTrait::Display => Ok(StringDeriveTrait::Display),
+        NormalDeriveTrait::Default => Ok(StringDeriveTrait::Default),
         NormalDeriveTrait::Clone => Ok(StringDeriveTrait::Clone),
         NormalDeriveTrait::PartialEq => Ok(StringDeriveTrait::PartialEq),
         NormalDeriveTrait::Eq => Ok(StringDeriveTrait::Eq),

--- a/test_suite/tests/float.rs
+++ b/test_suite/tests/float.rs
@@ -591,6 +591,45 @@ mod traits {
             assert_eq!(offset.into_inner(), 13.3);
         }
     }
+
+    #[cfg(test)]
+    mod trait_default {
+        use super::*;
+
+        #[test]
+        fn test_default_without_validation() {
+            #[nutype(default = 13.0)]
+            #[derive(Default)]
+            pub struct Number(f32);
+
+            assert_eq!(Number::default().into_inner(), 13.0);
+        }
+
+        #[test]
+        fn test_default_with_validation_when_valid() {
+            #[nutype(
+                validate(max = 20.0)
+                default = 13.0
+            )]
+            #[derive(Default)]
+            pub struct Number(f64);
+
+            assert_eq!(Number::default().into_inner(), 13.0);
+        }
+
+        #[test]
+        #[should_panic(expected = "Default value for type Number is invalid")]
+        fn test_default_with_validation_when_invalid() {
+            #[nutype(
+                validate(max = 20.0)
+                default = 20.1
+            )]
+            #[derive(Default)]
+            pub struct Number(f64);
+
+            Number::default();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/test_suite/tests/integer.rs
+++ b/test_suite/tests/integer.rs
@@ -561,6 +561,45 @@ mod traits {
             assert_eq!(offset.into_inner(), 13);
         }
     }
+
+    #[cfg(test)]
+    mod trait_default {
+        use super::*;
+
+        #[test]
+        fn test_default_without_validation() {
+            #[nutype(default = 13)]
+            #[derive(Default)]
+            pub struct Number(i8);
+
+            assert_eq!(Number::default().into_inner(), 13);
+        }
+
+        #[test]
+        fn test_default_with_validation_when_valid() {
+            #[nutype(
+                validate(max = 20)
+                default = 13
+            )]
+            #[derive(Default)]
+            pub struct Number(i8);
+
+            assert_eq!(Number::default().into_inner(), 13);
+        }
+
+        #[test]
+        #[should_panic(expected = "Default value for type Number is invalid")]
+        fn test_default_with_validation_when_invalid() {
+            #[nutype(
+                validate(max = 20)
+                default = 21
+            )]
+            #[derive(Default)]
+            pub struct Number(i16);
+
+            Number::default();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/test_suite/tests/string.rs
+++ b/test_suite/tests/string.rs
@@ -404,6 +404,45 @@ mod derives {
         assert_eq!(name.to_string(), "Serhii");
     }
 
+    #[cfg(test)]
+    mod trait_default {
+        use super::*;
+
+        #[test]
+        fn test_default_without_validation() {
+            #[nutype(default = "Anonymous")]
+            #[derive(Default)]
+            pub struct Name(String);
+
+            assert_eq!(Name::default().into_inner(), "Anonymous");
+        }
+
+        #[test]
+        fn test_default_with_validation_when_valid() {
+            #[nutype(
+                validate(min_len = 5)
+                default = "Anonymous"
+            )]
+            #[derive(Default)]
+            pub struct Name(String);
+
+            assert_eq!(Name::default().into_inner(), "Anonymous");
+        }
+
+        #[test]
+        #[should_panic(expected = "Default value for type Name is invalid")]
+        fn test_default_with_validation_when_invalid() {
+            #[nutype(
+                validate(min_len = 5)
+                default = "Nope"
+            )]
+            #[derive(Default)]
+            pub struct Name(String);
+
+            Name::default();
+        }
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn test_trait_serialize() {

--- a/test_suite/tests/ui/integer/derive/default.rs
+++ b/test_suite/tests/ui/integer/derive/default.rs
@@ -1,0 +1,7 @@
+use nutype::nutype;
+
+#[nutype(validate(max = 1024))]
+#[derive(Default)]
+pub struct Count(i32);
+
+fn main() {}

--- a/test_suite/tests/ui/integer/derive/default.stderr
+++ b/test_suite/tests/ui/integer/derive/default.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> tests/ui/integer/derive/default.rs:3:1
+  |
+3 | #[nutype(validate(max = 1024))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Default trait is derived for type Count, but `default = ` parameter is missing in #[nutype] macro


### PR DESCRIPTION
Fixes https://github.com/greyblake/nutype/issues/36

This PR allow deriving `Default` like it was proposed in issue #36 

```rs
#[nutype(
    validate(min = 0.0, max = 100.0)
    default = 50.0
)]
#[derive(Default)]
pub struct Percent(f64)
```

## TODO


* [x] parsing with attribute Default and generating proper `Default` implementation
* [x] Unit tests
* [x] Make sure that: `default = ` and `derive(Default)` are rather both present or both absent. Otherwise show compilation error
* [x] UI test
* [x] Documentation
  * [x] README
  * [x] lib.rs