### PR TITLE
Use darling::Error instead of syn::Error

### DIFF
--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -255,18 +255,18 @@ pub trait Newtype {
     #[allow(clippy::type_complexity)]
     fn parse_attributes(
         attrs: TokenStream,
-    ) -> Result<Attributes<Guard<Self::Sanitizer, Self::Validator>>, syn::Error>;
+    ) -> Result<Attributes<Guard<Self::Sanitizer, Self::Validator>>, darling::Error>;
 
     fn validate(
         guard: &Guard<Self::Sanitizer, Self::Validator>,
         derive_traits: Vec<SpannedValue<DeriveTrait>>,
-    ) -> Result<HashSet<Self::TypedTrait>, syn::Error>;
+    ) -> Result<HashSet<Self::TypedTrait>, darling::Error>;
 
     fn generate(
         params: GenerateParams<Self::TypedTrait, Guard<Self::Sanitizer, Self::Validator>>,
     ) -> TokenStream;
 
-    fn expand(typed_meta: TypedMeta) -> Result<TokenStream, syn::Error> {
+    fn expand(typed_meta: TypedMeta) -> Result<TokenStream, darling::Error> {
         let TypedMeta {
             doc_attrs,
             type_name,

--- a/nutype_macros/src/common/validate.rs
+++ b/nutype_macros/src/common/validate.rs
@@ -5,13 +5,13 @@ use proc_macro2::Span;
 pub fn validate_duplicates<T: Kind>(
     items: &[SpannedValue<T>],
     build_error_msg: impl Fn(<T as Kind>::Kind) -> String,
-) -> Result<(), syn::Error> {
+) -> Result<(), darling::Error> {
     if let Some((item1, item2)) = detect_items_of_same_kind(items) {
         assert_eq!(item1.kind(), item2.kind());
         let kind = item1.kind();
         let msg = build_error_msg(kind);
         let span = join_spans_or_last(item1.span(), item2.span());
-        let err = syn::Error::new(span, msg);
+        let err = syn::Error::new(span, msg).into();
         return Err(err);
     }
     Ok(())

--- a/nutype_macros/src/float/mod.rs
+++ b/nutype_macros/src/float/mod.rs
@@ -28,14 +28,14 @@ where
     type Validator = FloatValidator<T>;
     type TypedTrait = FloatDeriveTrait;
 
-    fn parse_attributes(attrs: TokenStream) -> Result<Attributes<FloatGuard<T>>, syn::Error> {
+    fn parse_attributes(attrs: TokenStream) -> Result<Attributes<FloatGuard<T>>, darling::Error> {
         parse::parse_attributes::<T>(attrs)
     }
 
     fn validate(
         guard: &Guard<Self::Sanitizer, Self::Validator>,
         derive_traits: Vec<SpannedValue<DeriveTrait>>,
-    ) -> Result<HashSet<Self::TypedTrait>, syn::Error> {
+    ) -> Result<HashSet<Self::TypedTrait>, darling::Error> {
         validate_float_derive_traits(derive_traits, guard)
     }
 

--- a/nutype_macros/src/float/parse.rs
+++ b/nutype_macros/src/float/parse.rs
@@ -18,7 +18,7 @@ use super::{
     validate::validate_number_meta,
 };
 
-pub fn parse_attributes<T>(input: TokenStream) -> Result<Attributes<FloatGuard<T>>, syn::Error>
+pub fn parse_attributes<T>(input: TokenStream) -> Result<Attributes<FloatGuard<T>>, darling::Error>
 where
     T: FromStr + PartialOrd + Clone,
     <T as FromStr>::Err: Debug,
@@ -37,7 +37,9 @@ where
     })
 }
 
-fn parse_raw_attributes<T>(input: TokenStream) -> Result<Attributes<FloatRawGuard<T>>, syn::Error>
+fn parse_raw_attributes<T>(
+    input: TokenStream,
+) -> Result<Attributes<FloatRawGuard<T>>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -45,7 +47,9 @@ where
     parse_nutype_attributes(parse_sanitize_attrs, parse_validate_attrs)(input)
 }
 
-fn parse_sanitize_attrs<T>(stream: TokenStream) -> Result<Vec<SpannedFloatSanitizer<T>>, syn::Error>
+fn parse_sanitize_attrs<T>(
+    stream: TokenStream,
+) -> Result<Vec<SpannedFloatSanitizer<T>>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -54,7 +58,9 @@ where
     split_and_parse(tokens, is_comma, parse_sanitize_attr)
 }
 
-fn parse_sanitize_attr<T>(tokens: Vec<TokenTree>) -> Result<SpannedFloatSanitizer<T>, syn::Error>
+fn parse_sanitize_attr<T>(
+    tokens: Vec<TokenTree>,
+) -> Result<SpannedFloatSanitizer<T>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -72,16 +78,18 @@ where
             }
             unknown_sanitizer => {
                 let msg = format!("Unknown sanitizer `{unknown_sanitizer}`");
-                let error = syn::Error::new(ident.span(), msg);
+                let error = syn::Error::new(ident.span(), msg).into();
                 Err(error)
             }
         }
     } else {
-        Err(syn::Error::new(Span::call_site(), "Invalid syntax."))
+        Err(syn::Error::new(Span::call_site(), "Invalid syntax.").into())
     }
 }
 
-fn parse_validate_attrs<T>(stream: TokenStream) -> Result<Vec<SpannedFloatValidator<T>>, syn::Error>
+fn parse_validate_attrs<T>(
+    stream: TokenStream,
+) -> Result<Vec<SpannedFloatValidator<T>>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -90,7 +98,9 @@ where
     split_and_parse(tokens, is_comma, parse_validate_attr)
 }
 
-fn parse_validate_attr<T>(tokens: Vec<TokenTree>) -> Result<SpannedFloatValidator<T>, syn::Error>
+fn parse_validate_attr<T>(
+    tokens: Vec<TokenTree>,
+) -> Result<SpannedFloatValidator<T>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -125,11 +135,11 @@ where
             }
             unknown_validator => {
                 let msg = format!("Unknown validation rule `{unknown_validator}`");
-                let error = syn::Error::new(ident.span(), msg);
+                let error = syn::Error::new(ident.span(), msg).into();
                 Err(error)
             }
         }
     } else {
-        Err(syn::Error::new(Span::call_site(), "Invalid syntax."))
+        Err(syn::Error::new(Span::call_site(), "Invalid syntax.").into())
     }
 }

--- a/nutype_macros/src/integer/mod.rs
+++ b/nutype_macros/src/integer/mod.rs
@@ -31,14 +31,14 @@ where
     type Validator = IntegerValidator<T>;
     type TypedTrait = IntegerDeriveTrait;
 
-    fn parse_attributes(attrs: TokenStream) -> Result<Attributes<IntegerGuard<T>>, syn::Error> {
+    fn parse_attributes(attrs: TokenStream) -> Result<Attributes<IntegerGuard<T>>, darling::Error> {
         parse::parse_attributes::<T>(attrs)
     }
 
     fn validate(
         guard: &Guard<Self::Sanitizer, Self::Validator>,
         derive_traits: Vec<SpannedValue<DeriveTrait>>,
-    ) -> Result<HashSet<Self::TypedTrait>, syn::Error> {
+    ) -> Result<HashSet<Self::TypedTrait>, darling::Error> {
         let has_validation = guard.has_validation();
         validate_integer_derive_traits(derive_traits, has_validation)
     }

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -18,7 +18,9 @@ use super::{
     validate::validate_number_meta,
 };
 
-pub fn parse_attributes<T>(input: TokenStream) -> Result<Attributes<IntegerGuard<T>>, syn::Error>
+pub fn parse_attributes<T>(
+    input: TokenStream,
+) -> Result<Attributes<IntegerGuard<T>>, darling::Error>
 where
     T: FromStr + PartialOrd + Clone,
     <T as FromStr>::Err: Debug,
@@ -37,7 +39,9 @@ where
     })
 }
 
-fn parse_raw_attributes<T>(input: TokenStream) -> Result<Attributes<IntegerRawGuard<T>>, syn::Error>
+fn parse_raw_attributes<T>(
+    input: TokenStream,
+) -> Result<Attributes<IntegerRawGuard<T>>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -47,7 +51,7 @@ where
 
 fn parse_sanitize_attrs<T>(
     stream: TokenStream,
-) -> Result<Vec<SpannedIntegerSanitizer<T>>, syn::Error>
+) -> Result<Vec<SpannedIntegerSanitizer<T>>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -56,7 +60,9 @@ where
     split_and_parse(tokens, is_comma, parse_sanitize_attr)
 }
 
-fn parse_sanitize_attr<T>(tokens: Vec<TokenTree>) -> Result<SpannedIntegerSanitizer<T>, syn::Error>
+fn parse_sanitize_attr<T>(
+    tokens: Vec<TokenTree>,
+) -> Result<SpannedIntegerSanitizer<T>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -74,18 +80,18 @@ where
             }
             unknown_sanitizer => {
                 let msg = format!("Unknown sanitizer `{unknown_sanitizer}`");
-                let error = syn::Error::new(ident.span(), msg);
+                let error = syn::Error::new(ident.span(), msg).into();
                 Err(error)
             }
         }
     } else {
-        Err(syn::Error::new(Span::call_site(), "Invalid syntax."))
+        Err(syn::Error::new(Span::call_site(), "Invalid syntax.").into())
     }
 }
 
 fn parse_validate_attrs<T>(
     stream: TokenStream,
-) -> Result<Vec<SpannedIntegerValidator<T>>, syn::Error>
+) -> Result<Vec<SpannedIntegerValidator<T>>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -94,7 +100,9 @@ where
     split_and_parse(tokens, is_comma, parse_validate_attr)
 }
 
-fn parse_validate_attr<T>(tokens: Vec<TokenTree>) -> Result<SpannedIntegerValidator<T>, syn::Error>
+fn parse_validate_attr<T>(
+    tokens: Vec<TokenTree>,
+) -> Result<SpannedIntegerValidator<T>, darling::Error>
 where
     T: FromStr,
     <T as FromStr>::Err: Debug,
@@ -124,11 +132,11 @@ where
             }
             unknown_validator => {
                 let msg = format!("Unknown validation rule `{unknown_validator}`");
-                let error = syn::Error::new(ident.span(), msg);
+                let error = syn::Error::new(ident.span(), msg).into();
                 Err(error)
             }
         }
     } else {
-        Err(syn::Error::new(Span::call_site(), "Invalid syntax."))
+        Err(syn::Error::new(Span::call_site(), "Invalid syntax.").into())
     }
 }

--- a/nutype_macros/src/integer/validate.rs
+++ b/nutype_macros/src/integer/validate.rs
@@ -12,7 +12,9 @@ use super::models::{
     SpannedIntegerSanitizer, SpannedIntegerValidator,
 };
 
-pub fn validate_number_meta<T>(raw_meta: IntegerRawGuard<T>) -> Result<IntegerGuard<T>, syn::Error>
+pub fn validate_number_meta<T>(
+    raw_meta: IntegerRawGuard<T>,
+) -> Result<IntegerGuard<T>, darling::Error>
 where
     T: PartialOrd + Clone,
 {
@@ -36,7 +38,7 @@ where
 
 fn validate_validators<T>(
     validators: Vec<SpannedIntegerValidator<T>>,
-) -> Result<Vec<IntegerValidator<T>>, syn::Error>
+) -> Result<Vec<IntegerValidator<T>>, darling::Error>
 where
     T: PartialOrd + Clone,
 {
@@ -62,7 +64,7 @@ where
     if let (Some((_min_span, min)), Some((max_span, max))) = (maybe_min, maybe_max) {
         if min > max {
             let msg = "`min` cannot be greater than `max`.\nSometimes we all need a little break.";
-            let err = syn::Error::new(max_span, msg);
+            let err = syn::Error::new(max_span, msg).into();
             return Err(err);
         }
     }
@@ -76,7 +78,7 @@ where
 
 fn validate_sanitizers<T>(
     sanitizers: Vec<SpannedIntegerSanitizer<T>>,
-) -> Result<Vec<IntegerSanitizer<T>>, syn::Error>
+) -> Result<Vec<IntegerSanitizer<T>>, darling::Error>
 where
     T: PartialOrd + Clone,
 {
@@ -94,7 +96,7 @@ where
 pub fn validate_integer_derive_traits(
     spanned_derive_traits: Vec<SpannedDeriveTrait>,
     has_validation: bool,
-) -> Result<HashSet<IntegerDeriveTrait>, syn::Error> {
+) -> Result<HashSet<IntegerDeriveTrait>, darling::Error> {
     let mut traits = HashSet::with_capacity(24);
 
     for spanned_trait in spanned_derive_traits {
@@ -140,7 +142,7 @@ fn to_integer_derive_trait(
     tr: NormalDeriveTrait,
     has_validation: bool,
     span: Span,
-) -> Result<IntegerDeriveTrait, syn::Error> {
+) -> Result<IntegerDeriveTrait, darling::Error> {
     match tr {
         NormalDeriveTrait::Debug => Ok(IntegerDeriveTrait::Debug),
         NormalDeriveTrait::Display => Ok(IntegerDeriveTrait::Display),
@@ -163,7 +165,7 @@ fn to_integer_derive_trait(
         NormalDeriveTrait::TryFrom => Ok(IntegerDeriveTrait::TryFrom),
         NormalDeriveTrait::From => {
             if has_validation {
-                Err(syn::Error::new(span, "#[nutype] cannot derive `From` trait, because there is validation defined. Use `TryFrom` instead."))
+                Err(syn::Error::new(span, "#[nutype] cannot derive `From` trait, because there is validation defined. Use `TryFrom` instead.").into())
             } else {
                 Ok(IntegerDeriveTrait::From)
             }

--- a/nutype_macros/src/lib.rs
+++ b/nutype_macros/src/lib.rs
@@ -18,14 +18,14 @@ pub fn nutype(
     type_definition: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     expand_nutype(attrs.into(), type_definition.into())
-        .unwrap_or_else(|e| syn::Error::to_compile_error(&e))
+        .unwrap_or_else(|e| e.write_errors())
         .into()
 }
 
 fn expand_nutype(
     attrs: TokenStream,
     type_definition: TokenStream,
-) -> Result<TokenStream, syn::Error> {
+) -> Result<TokenStream, darling::Error> {
     use FloatInnerType::*;
     use IntegerInnerType::*;
 

--- a/nutype_macros/src/string/mod.rs
+++ b/nutype_macros/src/string/mod.rs
@@ -22,14 +22,14 @@ impl Newtype for StringNewtype {
     type Validator = StringValidator;
     type TypedTrait = StringDeriveTrait;
 
-    fn parse_attributes(attrs: TokenStream) -> Result<Attributes<StringGuard>, syn::Error> {
+    fn parse_attributes(attrs: TokenStream) -> Result<Attributes<StringGuard>, darling::Error> {
         parse::parse_attributes(attrs)
     }
 
     fn validate(
         guard: &StringGuard,
         derive_traits: Vec<SpannedValue<DeriveTrait>>,
-    ) -> Result<HashSet<Self::TypedTrait>, syn::Error> {
+    ) -> Result<HashSet<Self::TypedTrait>, darling::Error> {
         validate_string_derive_traits(guard, derive_traits)
     }
 

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -12,7 +12,7 @@ use proc_macro2::{Span, TokenStream, TokenTree};
 use super::models::{RegexDef, SpannedStringSanitizer, SpannedStringValidator};
 use super::validate::validate_string_meta;
 
-pub fn parse_attributes(input: TokenStream) -> Result<Attributes<StringGuard>, syn::Error> {
+pub fn parse_attributes(input: TokenStream) -> Result<Attributes<StringGuard>, darling::Error> {
     let raw_attrs = parse_raw_attributes(input)?;
     let Attributes {
         new_unchecked,
@@ -27,16 +27,18 @@ pub fn parse_attributes(input: TokenStream) -> Result<Attributes<StringGuard>, s
     })
 }
 
-fn parse_raw_attributes(input: TokenStream) -> Result<Attributes<StringRawGuard>, syn::Error> {
+fn parse_raw_attributes(input: TokenStream) -> Result<Attributes<StringRawGuard>, darling::Error> {
     parse_nutype_attributes(parse_sanitize_attrs, parse_validate_attrs)(input)
 }
 
-fn parse_sanitize_attrs(stream: TokenStream) -> Result<Vec<SpannedStringSanitizer>, syn::Error> {
+fn parse_sanitize_attrs(
+    stream: TokenStream,
+) -> Result<Vec<SpannedStringSanitizer>, darling::Error> {
     let tokens: Vec<TokenTree> = stream.into_iter().collect();
     split_and_parse(tokens, is_comma, parse_sanitize_attr)
 }
 
-fn parse_sanitize_attr(tokens: Vec<TokenTree>) -> Result<SpannedStringSanitizer, syn::Error> {
+fn parse_sanitize_attr(tokens: Vec<TokenTree>) -> Result<SpannedStringSanitizer, darling::Error> {
     let mut token_iter = tokens.iter();
     let token = token_iter.next();
     if let Some(TokenTree::Ident(ident)) = token {
@@ -51,17 +53,19 @@ fn parse_sanitize_attr(tokens: Vec<TokenTree>) -> Result<SpannedStringSanitizer,
             }
             unknown_sanitizer => {
                 let msg = format!("Unknown sanitizer `{unknown_sanitizer}`");
-                let error = syn::Error::new(ident.span(), msg);
+                let error = syn::Error::new(ident.span(), msg).into();
                 return Err(error);
             }
         };
         Ok(SpannedStringSanitizer::new(san, ident.span()))
     } else {
-        Err(syn::Error::new(Span::call_site(), "Invalid syntax."))
+        Err(syn::Error::new(Span::call_site(), "Invalid syntax.").into())
     }
 }
 
-fn parse_validate_attrs(stream: TokenStream) -> Result<Vec<SpannedStringValidator>, syn::Error> {
+fn parse_validate_attrs(
+    stream: TokenStream,
+) -> Result<Vec<SpannedStringValidator>, darling::Error> {
     let tokens: Vec<TokenTree> = stream.into_iter().collect();
     split_and_parse(tokens, is_comma, parse_validate_attr)
 }
@@ -69,7 +73,7 @@ fn parse_validate_attrs(stream: TokenStream) -> Result<Vec<SpannedStringValidato
 // TODO: refactor
 // * Avoid unnecessary allocations
 // * Replace `parse_value_as_number()` with something better
-fn parse_validate_attr(tokens: Vec<TokenTree>) -> Result<SpannedStringValidator, syn::Error> {
+fn parse_validate_attr(tokens: Vec<TokenTree>) -> Result<SpannedStringValidator, darling::Error> {
     let mut token_iter = tokens.into_iter();
     let token = token_iter.next();
     if let Some(TokenTree::Ident(ident)) = token {
@@ -114,18 +118,18 @@ fn parse_validate_attr(tokens: Vec<TokenTree>) -> Result<SpannedStringValidator,
                             "IMPORTANT: Make sure that your crate EXPLICITLY depends on `regex` and `lazy_static` crates.\n",
                             "And... don't forget to take care of yourself and your beloved ones. That is even more important.",
                         );
-                        return Err(syn::Error::new(ident.span(), msg));
+                        return Err(syn::Error::new(ident.span(), msg)).into();
                     }
                 )
             }
             validator => {
                 let msg = format!("Unknown validation rule `{validator}`");
-                let error = syn::Error::new(ident.span(), msg);
+                let error = syn::Error::new(ident.span(), msg).into();
                 Err(error)
             }
         }
     } else {
-        Err(syn::Error::new(Span::call_site(), "Invalid syntax."))
+        Err(syn::Error::new(Span::call_site(), "Invalid syntax.").into())
     }
 }
 
@@ -133,7 +137,7 @@ fn parse_validate_attr(tokens: Vec<TokenTree>) -> Result<SpannedStringValidator,
 fn parse_regex(
     stream: TokenStream,
     span: proc_macro2::Span,
-) -> Result<(RegexDef, Span), syn::Error> {
+) -> Result<(RegexDef, Span), darling::Error> {
     let token = stream.into_iter().next().ok_or_else(|| {
         syn::Error::new(span, "Expected a regex or an ident that refers to regex.")
     })?;
@@ -145,6 +149,7 @@ fn parse_regex(
         TokenTree::Group(..) | TokenTree::Punct(..) => Err(syn::Error::new(
             span,
             "regex must be a string or an ident that refers to Regex constant",
-        )),
+        )
+        .into()),
     }
 }


### PR DESCRIPTION
This enables usage of `darling` for macro attributes parsing.