### PR TITLE
Darling string

### DIFF
--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,7 +1,14 @@
 use nutype::nutype;
+use once_cell::sync::Lazy;
+use regex::Regex;
 
-#[nutype(validate(finite))]
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
-pub struct Weight(f64);
+static PHONE_REGEX_ONCE_CELL: Lazy<Regex> = Lazy::new(|| Regex::new("[0-9]{3}-[0-9]{3}$").unwrap());
+
+// #[nutype(
+//     validate(regex = "foo")
+// )]
+#[nutype(validate(regex = self::PHONE_REGEX_ONCE_CELL))]
+#[derive(Debug)]
+pub struct Name(String);
 
 fn main() {}

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -237,9 +237,9 @@ pub fn gen_string_validate_fn(type_name: &TypeName, validators: &[StringValidato
                         )
 
                     }
-                    RegexDef::Ident(regex_ident) => {
+                    RegexDef::Path(regex_path) => {
                         quote!(
-                            if !#regex_ident.is_match(&val) {
+                            if !#regex_path.is_match(&val) {
                                 return Err(#error_name::RegexMismatch);
                             }
                         )

--- a/nutype_macros/src/string/models.rs
+++ b/nutype_macros/src/string/models.rs
@@ -70,11 +70,11 @@ pub enum StringValidator {
 pub enum RegexDef {
     /// The case, when regex is defined with string literal inlined, e.g.:
     ///     regex = "^[0-9]{9}$"
-    StringLiteral(proc_macro2::Literal),
+    StringLiteral(syn::LitStr),
 
     /// The case, when regex is with an ident, that refers to regex constant:
     ///     regex = SSN_REGEX
-    Ident(proc_macro2::Ident),
+    Path(syn::Path),
 }
 
 impl Kind for StringValidator {

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -158,7 +158,7 @@ impl ParseableStringValidator {
                             "IMPORTANT: Make sure that your crate EXPLICITLY depends on `regex` and `lazy_static` crates.\n",
                             "And... don't forget to take care of yourself and your beloved ones. That is even more important.",
                         );
-                        return Err(syn::Error::new(span, msg)).into();
+                        return Err(syn::Error::new(span, msg).into());
                     }
                 )
             }
@@ -186,7 +186,7 @@ impl FromMeta for RegexDef {
                     syn::Meta::NameValue(name_value) => match &name_value.value {
                         syn::Expr::Path(expr_path) => {
                             let path = expr_path.path.to_owned();
-                            return Ok(Self::Path(path));
+                            Ok(Self::Path(path))
                         }
                         _ => Err(build_err()),
                     },
@@ -196,4 +196,3 @@ impl FromMeta for RegexDef {
         }
     }
 }
-

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -6,6 +6,7 @@ use crate::string::models::StringRawGuard;
 use crate::string::models::{StringSanitizer, StringValidator};
 use crate::utils::match_feature;
 use darling::export::NestedMeta;
+use darling::util::Flag;
 use darling::util::SpannedValue;
 use darling::FromMeta;
 use proc_macro2::TokenStream;
@@ -90,9 +91,9 @@ define_parseable_enum! {
     parseable_name: ParseableStringSanitizer,
     raw_name: RawStringSanitizer,
     variants: {
-        Trim: bool,
-        Lowercase: bool,
-        Uppercase: bool,
+        Trim: Flag,
+        Lowercase: Flag,
+        Uppercase: Flag,
         With: Expr,
     }
 }
@@ -106,12 +107,12 @@ impl ParseableStringSanitizer {
         let raw = spanned_raw.as_ref();
 
         let maybe_sanitizer = match raw {
-            Trim(true) => Some(StringSanitizer::Trim),
-            Trim(false) => None,
-            Lowercase(true) => Some(StringSanitizer::Lowercase),
-            Lowercase(false) => None,
-            Uppercase(true) => Some(StringSanitizer::Uppercase),
-            Uppercase(false) => None,
+            Trim(flag) if flag.is_present() => Some(StringSanitizer::Trim),
+            Trim(_) => None,
+            Lowercase(flag) if flag.is_present() => Some(StringSanitizer::Lowercase),
+            Lowercase(_) => None,
+            Uppercase(flag) if flag.is_present() => Some(StringSanitizer::Uppercase),
+            Uppercase(_) => None,
             With(expr) => Some(StringSanitizer::With(quote::quote!(#expr))),
         };
 
@@ -125,7 +126,7 @@ define_parseable_enum! {
     variants: {
         MinLen: usize,
         MaxLen: usize,
-        NotEmpty: bool,
+        NotEmpty: Flag,
         With: Expr,
         Regex: RegexDef,
     }
@@ -144,8 +145,8 @@ impl ParseableStringValidator {
         let maybe_validator = match raw {
             MinLen(min) => Some(StringValidator::MinLen(*min)),
             MaxLen(max) => Some(StringValidator::MaxLen(*max)),
-            NotEmpty(true) => Some(StringValidator::NotEmpty),
-            NotEmpty(false) => None,
+            NotEmpty(flag) if flag.is_present() => Some(StringValidator::NotEmpty),
+            NotEmpty(_) => None,
             With(expr) => Some(StringValidator::With(quote::quote!(#expr))),
             Regex(regex_def) => {
                 match_feature!("regex",

--- a/nutype_macros/src/string/validate.rs
+++ b/nutype_macros/src/string/validate.rs
@@ -201,67 +201,18 @@ fn to_string_derive_trait(
 mod regex_validation {
     use super::*;
     use crate::string::models::RegexDef;
-    use proc_macro2::Literal;
-    use std::collections::VecDeque;
 
     pub fn validate_regex_def(regex_def: &RegexDef, span: Span) -> Result<(), darling::Error> {
         match regex_def {
             RegexDef::StringLiteral(lit) => {
                 // Try to validate regex at compile time if it's a string literal
-                let regex_str = literal_to_string(lit)?;
+                let regex_str = lit.value();
                 match regex::Regex::new(&regex_str) {
                     Ok(_re) => Ok(()),
                     Err(err) => Err(syn::Error::new(span, format!("{err}")).into()),
                 }
             }
-            RegexDef::Ident(_) => Ok(()),
+            RegexDef::Path(_) => Ok(()),
         }
-    }
-
-    // TODO: write unit tests
-    fn literal_to_string(lit: &Literal) -> Result<String, darling::Error> {
-        let value = lit.to_string();
-        if let Some(s) = unquote_double_quotes(&value) {
-            Ok(s)
-        } else if let Some(s) = unoquote_inline_doc(&value) {
-            Ok(s)
-        } else {
-            let msg = format!("Could not obtain regex string from the literal: {lit}");
-            Err(syn::Error::new(lit.span(), msg).into())
-        }
-    }
-
-    // Input:
-    //     "^bar{2}$"
-    // Output:
-    //     ^bar{2}$
-    // TODO: write unit tests
-    fn unquote_double_quotes(input: &str) -> Option<String> {
-        let len = input.len();
-        if len > 1 && input.starts_with('"') && input.ends_with('"') {
-            let output = input[1..(len - 1)].to_string();
-            Some(output)
-        } else {
-            None
-        }
-    }
-
-    // Input:
-    //     r##"^bar{2}$"##
-    // Output:
-    //     ^bar{2}$
-    // TODO: write unit tests
-    fn unoquote_inline_doc(input: &str) -> Option<String> {
-        let mut chars: VecDeque<char> = input.chars().collect();
-
-        chars.pop_front(); // get rid of `r`
-        while let Some(front_ch) = chars.pop_front() {
-            chars.pop_back();
-            if front_ch == '"' {
-                let output: String = chars.into_iter().collect();
-                return Some(output);
-            }
-        }
-        None
     }
 }

--- a/test_suite/tests/string.rs
+++ b/test_suite/tests/string.rs
@@ -16,14 +16,6 @@ mod sanitizers {
     }
 
     #[test]
-    fn test_trim_false() {
-        #[nutype(sanitize(trim = false))]
-        pub struct Name(String);
-
-        assert_eq!(Name::new(" foo ").into_inner(), " foo ");
-    }
-
-    #[test]
     fn test_lowercase() {
         #[nutype(sanitize(lowercase))]
         pub struct Name(String);
@@ -33,28 +25,12 @@ mod sanitizers {
     }
 
     #[test]
-    fn test_lowercase_false() {
-        #[nutype(sanitize(lowercase = false))]
-        pub struct Name(String);
-
-        assert_eq!(Name::new("FooBar").into_inner(), "FooBar");
-    }
-
-    #[test]
     fn test_uppercase() {
         #[nutype(sanitize(uppercase))]
         pub struct Name(String);
 
         assert_eq!(Name::new(" ").into_inner(), " ");
         assert_eq!(Name::new("Hello THERE").into_inner(), "HELLO THERE");
-    }
-
-    #[test]
-    fn test_uppercase_false() {
-        #[nutype(sanitize(uppercase = false))]
-        pub struct Name(String);
-
-        assert_eq!(Name::new("FooBar").into_inner(), "FooBar");
     }
 
     #[cfg(test)]

--- a/test_suite/tests/string.rs
+++ b/test_suite/tests/string.rs
@@ -16,6 +16,14 @@ mod sanitizers {
     }
 
     #[test]
+    fn test_trim_false() {
+        #[nutype(sanitize(trim = false))]
+        pub struct Name(String);
+
+        assert_eq!(Name::new(" foo ").into_inner(), " foo ");
+    }
+
+    #[test]
     fn test_lowercase() {
         #[nutype(sanitize(lowercase))]
         pub struct Name(String);
@@ -25,12 +33,28 @@ mod sanitizers {
     }
 
     #[test]
+    fn test_lowercase_false() {
+        #[nutype(sanitize(lowercase = false))]
+        pub struct Name(String);
+
+        assert_eq!(Name::new("FooBar").into_inner(), "FooBar");
+    }
+
+    #[test]
     fn test_uppercase() {
         #[nutype(sanitize(uppercase))]
         pub struct Name(String);
 
         assert_eq!(Name::new(" ").into_inner(), " ");
         assert_eq!(Name::new("Hello THERE").into_inner(), "HELLO THERE");
+    }
+
+    #[test]
+    fn test_uppercase_false() {
+        #[nutype(sanitize(uppercase = false))]
+        pub struct Name(String);
+
+        assert_eq!(Name::new("FooBar").into_inner(), "FooBar");
     }
 
     #[cfg(test)]

--- a/test_suite/tests/ui/string/sanitize/multiple_unknown.rs
+++ b/test_suite/tests/ui/string/sanitize/multiple_unknown.rs
@@ -1,6 +1,6 @@
 use nutype::nutype;
 
-#[nutype(sanitize(foo = true, trim = true, bar = true))]
+#[nutype(sanitize(foo, trim, bar))]
 pub struct Email(String);
 
 fn main() {}

--- a/test_suite/tests/ui/string/sanitize/multiple_unknown.rs
+++ b/test_suite/tests/ui/string/sanitize/multiple_unknown.rs
@@ -1,0 +1,6 @@
+use nutype::nutype;
+
+#[nutype(sanitize(foo = true, trim = true, bar = true))]
+pub struct Email(String);
+
+fn main() {}

--- a/test_suite/tests/ui/string/sanitize/multiple_unknown.stderr
+++ b/test_suite/tests/ui/string/sanitize/multiple_unknown.stderr
@@ -1,11 +1,11 @@
 error: Unknown field: `foo`
  --> tests/ui/string/sanitize/multiple_unknown.rs:3:19
   |
-3 | #[nutype(sanitize(foo = true, trim = true, bar = true))]
+3 | #[nutype(sanitize(foo, trim, bar))]
   |                   ^^^
 
 error: Unknown field: `bar`
- --> tests/ui/string/sanitize/multiple_unknown.rs:3:44
+ --> tests/ui/string/sanitize/multiple_unknown.rs:3:30
   |
-3 | #[nutype(sanitize(foo = true, trim = true, bar = true))]
-  |                                            ^^^
+3 | #[nutype(sanitize(foo, trim, bar))]
+  |                              ^^^

--- a/test_suite/tests/ui/string/sanitize/multiple_unknown.stderr
+++ b/test_suite/tests/ui/string/sanitize/multiple_unknown.stderr
@@ -1,0 +1,11 @@
+error: Unknown field: `foo`
+ --> tests/ui/string/sanitize/multiple_unknown.rs:3:19
+  |
+3 | #[nutype(sanitize(foo = true, trim = true, bar = true))]
+  |                   ^^^
+
+error: Unknown field: `bar`
+ --> tests/ui/string/sanitize/multiple_unknown.rs:3:44
+  |
+3 | #[nutype(sanitize(foo = true, trim = true, bar = true))]
+  |                                            ^^^

--- a/test_suite/tests/ui/string/sanitize/unknown.stderr
+++ b/test_suite/tests/ui/string/sanitize/unknown.stderr
@@ -1,4 +1,4 @@
-error: Unknown sanitizer `cleanup`
+error: Unknown field: `cleanup`
  --> tests/ui/string/sanitize/unknown.rs:3:19
   |
 3 | #[nutype(sanitize(cleanup = true))]

--- a/test_suite/tests/ui/string/validate/duplicated.stderr
+++ b/test_suite/tests/ui/string/validate/duplicated.stderr
@@ -1,6 +1,6 @@
 error: Duplicated validators `min_len`.
        Don't worry, you still remain ingenious!
- --> tests/ui/string/validate/duplicated.rs:3:47
+ --> tests/ui/string/validate/duplicated.rs:3:57
   |
 3 | #[nutype(validate(min_len = 5, max_len = 255, min_len = 6))]
-  |                                               ^^^^^^^
+  |                                                         ^

--- a/test_suite/tests/ui/string/validate/min_len_vs_max_len.stderr
+++ b/test_suite/tests/ui/string/validate/min_len_vs_max_len.stderr
@@ -1,6 +1,6 @@
 error: min_len cannot be greater than max_len.
        Don't you find this obvious?
- --> tests/ui/string/validate/min_len_vs_max_len.rs:3:34
+ --> tests/ui/string/validate/min_len_vs_max_len.rs:3:44
   |
 3 | #[nutype(validate(min_len = 127, max_len = 63))]
-  |                                  ^^^^^^^
+  |                                            ^^

--- a/test_suite/tests/ui/string/validate/unknown.stderr
+++ b/test_suite/tests/ui/string/validate/unknown.stderr
@@ -1,4 +1,4 @@
-error: Unknown validation rule `unique`
+error: Unknown field: `unique`
  --> tests/ui/string/validate/unknown.rs:3:19
   |
 3 | #[nutype(validate(unique))]


### PR DESCRIPTION
This is the first baby-step towards using darling to parse `nutype` attributes.

Here we define functions `parse_sanitize_attrs` and `parse_validate_attrs` for String  in terms of `darling`.