### PR TITLE
Refactor syn parse float

### DIFF
--- a/nutype_macros/src/common/parse/mod.rs
+++ b/nutype_macros/src/common/parse/mod.rs
@@ -2,269 +2,20 @@ pub mod meta;
 
 use std::{any::type_name, fmt::Debug, str::FromStr};
 
-use proc_macro2::{Group, Ident, Span, TokenStream, TokenTree};
+use proc_macro2::{Ident, Span, TokenTree};
 use syn::{
     parenthesized,
     parse::{Parse, ParseStream},
-    spanned::Spanned,
     token::Paren,
-    Expr, LitInt, Token,
+    Expr, Lit, Token,
 };
 
 use crate::{
-    common::models::{DeriveTrait, RawGuard, SpannedDeriveTrait},
+    common::models::{DeriveTrait, SpannedDeriveTrait},
     utils::match_feature,
 };
 
-use super::models::{Attributes, NewUnchecked};
-
-/// ## Example
-/// Input (token stream):
-///     = 123
-/// Output (parsed value):
-///    123
-pub fn parse_value_as_number<T, ITER>(mut iter: ITER) -> Result<(T, ITER), syn::Error>
-where
-    T: FromStr,
-    <T as FromStr>::Err: Debug,
-    ITER: Iterator<Item = TokenTree>,
-{
-    let token_eq = iter.next().expect("Expected token `=`");
-    assert_eq!(token_eq.to_string(), "=", "Expected token `=`");
-
-    let (num_str, span) = read_number(&mut iter)?;
-
-    let value: T = sanitize_number(&num_str).parse::<T>().map_err(|_err| {
-        let msg = format!("Expected {}, got `{}`", type_name::<T>(), num_str);
-        syn::Error::new(span, msg)
-    })?;
-
-    Ok((value, iter))
-}
-
-fn read_number<ITER>(iter: &mut ITER) -> Result<(String, Span), syn::Error>
-where
-    ITER: Iterator<Item = TokenTree>,
-{
-    let mut output = String::with_capacity(16);
-    let mut token_value = iter.next().expect("Expected number");
-    let span = token_value.span();
-    let mut t = token_value.to_string();
-
-    // If it starts with `-` (negative number), add it to output and parse the next token.
-    if t == "-" {
-        output.push_str(&t);
-        token_value = iter.next().expect("Expected number");
-        t = token_value.to_string();
-    }
-
-    output.push_str(&t);
-    Ok((output, span))
-}
-
-fn sanitize_number(val: &str) -> String {
-    val.replace('_', "")
-}
-
-pub fn try_unwrap_ident(token: TokenTree) -> Result<Ident, syn::Error> {
-    match token {
-        TokenTree::Ident(ident) => Ok(ident),
-        _ => {
-            let error = syn::Error::new(token.span(), "#[nutype] expected ident");
-            Err(error)
-        }
-    }
-}
-
-pub fn try_unwrap_group(token: TokenTree) -> Result<Group, syn::Error> {
-    match token {
-        TokenTree::Group(group) => Ok(group),
-        _ => {
-            let error = syn::Error::new(token.span(), "#[nutype] expected group");
-            Err(error)
-        }
-    }
-}
-
-pub fn parse_nutype_attributes<S, V>(
-    parse_sanitize_attrs: impl Fn(TokenStream) -> Result<Vec<S>, syn::Error>,
-    parse_validate_attrs: impl Fn(TokenStream) -> Result<Vec<V>, syn::Error>,
-) -> impl FnOnce(TokenStream) -> Result<Attributes<RawGuard<S, V>>, syn::Error> {
-    move |input: TokenStream| {
-        let mut raw_guard = RawGuard {
-            sanitizers: vec![],
-            validators: vec![],
-        };
-
-        // The variable `new_unchecked` is needed to be mutable for the case when `new_unchecked`
-        // feature flag is enabled.
-        #[allow(unused_mut)]
-        let mut new_unchecked = NewUnchecked::Off;
-
-        // Value which is used to derive Default trait
-        let mut maybe_default_value: Option<TokenStream> = None;
-
-        let mut iter = input.into_iter();
-
-        loop {
-            let token = match iter.next() {
-                Some(t) => t,
-                None => {
-                    let attributes = Attributes {
-                        guard: raw_guard,
-                        new_unchecked,
-                        maybe_default_value,
-                    };
-                    return Ok(attributes);
-                }
-            };
-
-            let ident = try_unwrap_ident(token)?;
-
-            match ident.to_string().as_ref() {
-                "sanitize" => {
-                    let token = iter.next().ok_or_else(|| {
-                        let msg = "`sanitize` must be used with parenthesis.\nFor example:\n\n    sanitize(trim)\n\n";
-                        syn::Error::new(ident.span(), msg)
-                    })?;
-                    let group = try_unwrap_group(token)?;
-                    let sanitize_stream = group.stream();
-                    raw_guard.sanitizers = parse_sanitize_attrs(sanitize_stream)?;
-                }
-                "validate" => {
-                    let token = iter.next().ok_or_else(|| {
-                        let msg = "`validate` must be used with parenthesis.\nFor example:\n\n    validate(max = 99)\n\n";
-                        syn::Error::new(ident.span(), msg)
-                    })?;
-                    let group = try_unwrap_group(token)?;
-                    let validate_stream = group.stream();
-                    raw_guard.validators = parse_validate_attrs(validate_stream)?;
-                }
-                "default" => {
-                    {
-                        // Take `=` sign
-                        if let Some(eq_t) = iter.next() {
-                            if !is_eq(&eq_t) {
-                                return Err(syn::Error::new(
-                                    ident.span(),
-                                    "Invalid syntax for `default`. Expected `=`, got `{eq_t}`",
-                                ));
-                            }
-                        } else {
-                            return Err(syn::Error::new(
-                                ident.span(),
-                                "Invalid syntax for `default`. Missing `=`",
-                            ));
-                        }
-                    }
-                    // TODO: parse it properly till some delimeter?
-                    let default_value = iter
-                        .next()
-                        .ok_or_else(|| syn::Error::new(ident.span(), "Missing default value"))?;
-                    maybe_default_value = Some(TokenStream::from(default_value));
-                }
-                "new_unchecked" => {
-                    match_feature!("new_unchecked",
-                        // The feature is not enabled, so we return an error
-                        on => {
-                            // Try to look forward and return a good helpful error if `new_unchecked` is
-                            // used incorrectly.
-                            // Correct:
-                            //    new_unchecked
-                            // Incorrect:
-                            //    new_unchecked()
-                            //    new_unchecked(foo = 13)
-                            let maybe_next_token = iter.clone().next();
-                            match maybe_next_token.map(try_unwrap_ident) {
-                                None | Some(Ok(_)) => {
-                                    new_unchecked = NewUnchecked::On;
-                                }
-                                Some(Err(err)) => {
-                                    let msg = "new_unchecked does not support any options";
-                                    return Err(syn::Error::new(err.span(), msg));
-                                }
-                            }
-                        },
-
-                        // The feature `new_unchecked` is enabled
-                        off => {
-                            let msg = "To generate ::new_unchecked() function, the feature `new_unchecked` of crate `nutype` needs to be enabled.\nBut you ought to know: generally, THIS IS A BAD IDEA.\nUse it only when you really need it.";
-                            return Err(syn::Error::new(ident.span(), msg));
-                        }
-                    )
-                }
-                unknown => {
-                    let msg = format!("Unknown #[nutype] option: `{unknown}`");
-                    let error = syn::Error::new(ident.span(), msg);
-                    return Err(error);
-                }
-            }
-        }
-    }
-}
-
-pub fn split_and_parse<SEP, PRS, OUT>(
-    tokens: Vec<TokenTree>,
-    is_separator: SEP,
-    parse: PRS,
-) -> Result<Vec<OUT>, syn::Error>
-where
-    SEP: Fn(&TokenTree) -> bool,
-    PRS: Fn(Vec<TokenTree>) -> Result<OUT, syn::Error>,
-{
-    tokens
-        .split(is_separator)
-        .filter(|subtokens| !subtokens.is_empty())
-        .map(|subtokens| parse(subtokens.to_owned()))
-        .collect()
-}
-
-pub fn is_comma(token: &TokenTree) -> bool {
-    match token {
-        TokenTree::Punct(punct) => punct.as_char() == ',',
-        _ => false,
-    }
-}
-
-pub fn is_eq(token: &TokenTree) -> bool {
-    match token {
-        TokenTree::Punct(punct) => punct.as_char() == '=',
-        _ => false,
-    }
-}
-
-// Context:
-//   with = |s: String| s.uppercase()
-// Input:
-//   = |s: String| s.to_uppercase()
-// Output
-//   |s: String| s.to_uppercase()
-pub fn parse_with_token_stream<'a>(
-    mut token_iter: impl Iterator<Item = &'a TokenTree>,
-    with_span: Span,
-) -> Result<TokenStream, syn::Error> {
-    {
-        // Take `=` sign
-        if let Some(eq_t) = token_iter.next() {
-            if !is_eq(eq_t) {
-                let span = with_span;
-                return Err(syn::Error::new(
-                    span,
-                    "Invalid syntax for `with`. Expected `=`, got `{eq_t}`",
-                ));
-            }
-        } else {
-            return Err(syn::Error::new(
-                with_span,
-                "Invalid syntax for `with`. Missing `=`",
-            ));
-        }
-    }
-
-    // Return the rest as TokenStream
-    let rest = TokenStream::from_iter(token_iter.cloned());
-    Ok(rest)
-}
+use super::models::NewUnchecked;
 
 pub fn is_doc_attribute(attribute: &syn::Attribute) -> bool {
     match attribute.path().segments.first() {
@@ -487,14 +238,9 @@ impl<Sanitizer: Parse, Validator: Parse> Parse for ParseableAttributes<Sanitizer
     }
 }
 
-pub fn parse_integer<T: FromStr>(input: ParseStream) -> syn::Result<(T, Span)> {
-    parse_number::<T, LitInt>(input)
-}
-
-fn parse_number<T, Literal>(input: ParseStream) -> syn::Result<(T, Span)>
+pub fn parse_number<T>(input: ParseStream) -> syn::Result<(T, Span)>
 where
     T: FromStr,
-    Literal: Parse + ToString + Spanned,
 {
     let mut number_str = String::with_capacity(16);
     if input.peek(Token![-]) {
@@ -502,8 +248,17 @@ where
         number_str.push('-');
     }
 
-    let lit: Literal = input.parse()?;
-    number_str.push_str(&lit.to_string().replace('_', ""));
+    let lit: Lit = input.parse()?;
+    let lit_str = match &lit {
+        Lit::Float(lf) => lf.to_string(),
+        Lit::Int(li) => li.to_string(),
+        _ => {
+            let msg = "Expected number literal";
+            return Err(syn::Error::new(lit.span(), msg));
+        }
+    };
+
+    number_str.push_str(&lit_str.replace('_', ""));
 
     let number: T = number_str.parse::<T>().map_err(|_err| {
         let msg = format!("Expected {}, got `{}`", type_name::<T>(), number_str);

--- a/nutype_macros/src/float/mod.rs
+++ b/nutype_macros/src/float/mod.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashSet, fmt::Debug, marker::PhantomData, str::FromStr};
+use std::{
+    collections::HashSet,
+    fmt::{Debug, Display},
+    marker::PhantomData,
+    str::FromStr,
+};
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;
@@ -21,7 +26,7 @@ pub struct FloatNewtype<T: FloatType>(PhantomData<T>);
 impl<T> Newtype for FloatNewtype<T>
 where
     T: FloatType + ToTokens + FromStr + PartialOrd + Clone,
-    <T as FromStr>::Err: Debug,
+    <T as FromStr>::Err: Debug + Display,
 {
     type Sanitizer = FloatSanitizer<T>;
     type Validator = FloatValidator<T>;

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
 use crate::common::models::Attributes;
-use crate::common::parse::{parse_integer, ParseableAttributes};
+use crate::common::parse::{parse_number, ParseableAttributes};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::spanned::Spanned;
@@ -57,14 +57,14 @@ where
 
         if ident == "min" {
             let _eq: Token![=] = input.parse()?;
-            let (number, span) = parse_integer::<T>(input)?;
+            let (number, span) = parse_number::<T>(input)?;
             Ok(SpannedIntegerValidator {
                 item: IntegerValidator::Min(number),
                 span,
             })
         } else if ident == "max" {
             let _eq: Token![=] = input.parse()?;
-            let (number, span) = parse_integer::<T>(input)?;
+            let (number, span) = parse_number::<T>(input)?;
             Ok(SpannedIntegerValidator {
                 item: IntegerValidator::Max(number),
                 span,

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -1,5 +1,5 @@
 use crate::common::models::{Attributes, SpannedItem};
-use crate::common::parse::{parse_integer, ParseableAttributes};
+use crate::common::parse::{parse_number, ParseableAttributes};
 use crate::string::models::StringGuard;
 use crate::string::models::StringRawGuard;
 use crate::string::models::{StringSanitizer, StringValidator};
@@ -75,14 +75,14 @@ impl Parse for SpannedStringValidator {
 
         if ident == "min_len" {
             let _: Token![=] = input.parse()?;
-            let (min_len, span) = parse_integer::<usize>(input)?;
+            let (min_len, span) = parse_number::<usize>(input)?;
             Ok(SpannedStringValidator {
                 item: StringValidator::MinLen(min_len),
                 span,
             })
         } else if ident == "max_len" {
             let _: Token![=] = input.parse()?;
-            let (max_len, span) = parse_integer::<usize>(input)?;
+            let (max_len, span) = parse_number::<usize>(input)?;
             Ok(SpannedStringValidator {
                 item: StringValidator::MaxLen(max_len),
                 span,

--- a/test_suite/tests/float.rs
+++ b/test_suite/tests/float.rs
@@ -233,7 +233,7 @@ mod types {
     #[test]
     fn test_f64_negative() {
         #[nutype(
-            sanitize(with = |n| n.clamp(-200.25, -5.0))
+            sanitize(with = |n| n.clamp(-200.25, -5.0)),
             validate(min = -100.25, max = -50.1)
         )]
         #[derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef)]
@@ -589,10 +589,7 @@ mod traits {
 
         #[test]
         fn test_default_with_validation_when_valid() {
-            #[nutype(
-                validate(max = 20.0)
-                default = 13.0
-            )]
+            #[nutype(validate(max = 20.0), default = 13.0)]
             #[derive(Default)]
             pub struct Number(f64);
 
@@ -602,10 +599,7 @@ mod traits {
         #[test]
         #[should_panic(expected = "Default value for type Number is invalid")]
         fn test_default_with_validation_when_invalid() {
-            #[nutype(
-                validate(max = 20.0)
-                default = 20.1
-            )]
+            #[nutype(validate(max = 20.0), default = 20.1)]
             #[derive(Default)]
             pub struct Number(f64);
 
@@ -621,10 +615,7 @@ mod new_unchecked {
 
     #[test]
     fn test_new_unchecked() {
-        #[nutype(
-            new_unchecked
-            validate(min = 50.0)
-        )]
+        #[nutype(new_unchecked, validate(min = 50.0))]
         pub struct Dist(f64);
 
         let dist = unsafe { Dist::new_unchecked(3.0) };

--- a/test_suite/tests/ui/float/sanitize/duplicated.stderr
+++ b/test_suite/tests/ui/float/sanitize/duplicated.stderr
@@ -1,6 +1,6 @@
 error: Duplicated sanitizer `with`.
        It happens, don't worry. We still love you!
- --> tests/ui/float/sanitize/duplicated.rs:6:9
+ --> tests/ui/float/sanitize/duplicated.rs:6:16
   |
 6 |         with = |n| n,
-  |         ^^^^
+  |                ^

--- a/test_suite/tests/ui/float/validate/duplicated.stderr
+++ b/test_suite/tests/ui/float/validate/duplicated.stderr
@@ -1,6 +1,6 @@
 error: Duplicated validator `max`.
        You're a great engineer, but don't forget to take care of yourself!
- --> tests/ui/float/validate/duplicated.rs:3:28
+ --> tests/ui/float/validate/duplicated.rs:3:34
   |
 3 | #[nutype(validate(max = 0, max = 0))]
-  |                            ^^^
+  |                                  ^

--- a/test_suite/tests/ui/float/validate/min_vs_max.stderr
+++ b/test_suite/tests/ui/float/validate/min_vs_max.stderr
@@ -1,6 +1,6 @@
 error: `min` cannot be greater than `max`.
        Sometimes we all need a little break.
- --> tests/ui/float/validate/min_vs_max.rs:3:19
+ --> tests/ui/float/validate/min_vs_max.rs:3:25
   |
 3 | #[nutype(validate(max = 0, min = 20))]
-  |                   ^^^
+  |                         ^

--- a/test_suite/tests/ui/float/validate/unknown.stderr
+++ b/test_suite/tests/ui/float/validate/unknown.stderr
@@ -1,4 +1,4 @@
-error: Unknown validation rule `meaningful`
+error: Unknown validator `meaningful`
  --> tests/ui/float/validate/unknown.rs:3:19
   |
 3 | #[nutype(validate(meaningful))]


### PR DESCRIPTION
Addresses #61 . Right now tests are not fixed yet. parse_number with Literal constraint didn't allow for an easy integer -> float conversion. While `parse::<f64>()` irom a string with an integer in it is straightforward, `LitInt` and `LitFloat` didn't enter the picture quite so smoothly hence why I opted for `Lit` enum pattern match, removing the need for Literal in the process.