### PR TITLE
Rename error variants to have Violated postfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 * [BREAKING] Validator `with` has been renamed to `predicate` to reflect the boolean nature of its range
 * [BREAKING] String validator `min_len` has been renamed to `char_len_min` to reflect that is based on UTF8 chars.
 * [BREAKING] String validator `max_len` has been renamed to `char_len_max` to reflect that is based on UTF8 chars.
+* [BREAKING] Rename error variants to follow the following formular: `<ValidationRule>Violated`. This implies the following renames:
+  * `TooShort` -> `CharLenMinViolated`
+  * `TooLong` -> `CharLenMaxViolated`
+  * `Empty` -> `NotEmptyViolated`
+  * `RegexMismatch` -> `RegexViolated`
+  * `Invalid` -> `PredicateViolated`
+  * `TooBig` -> `MaxViolated`
+  * `TooSmall` -> `MinViolated`
+  * `NotFinite` -> `FiniteViolated`
 * Better error messages: in case of unknown attribute, validator or sanitizer the possible values are listed.
 
 ### v0.3.1 - 2023-06-30

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -9,13 +9,10 @@ use nutype::nutype;
 )]
 pub struct Email(String);
 
-#[nutype(
-    validate(min = 100, max = 1000),
-    derive(Deref, FromStr)
-)]
+#[nutype(validate(min = 100, max = 1000), derive(Deref, FromStr))]
 pub struct Number(i16);
 
 fn main() {
-    let magic = Number::new(42);
+    let magic = Number::new(42).unwrap();
     assert_eq!(*magic, 42);
 }

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -2,14 +2,17 @@ use nutype::nutype;
 
 #[nutype(
     sanitize(trim, lowercase),
-    validate(not_empty),
+    validate(not_empty, char_len_max = 255, char_len_min = 6),
     derive(
         TryFrom, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
     )
 )]
 pub struct Email(String);
 
-#[nutype(derive(Deref))]
+#[nutype(
+    validate(min = 100, max = 1000),
+    derive(Deref, FromStr)
+)]
 pub struct Number(i16);
 
 fn main() {

--- a/nutype_macros/src/float/gen/error.rs
+++ b/nutype_macros/src/float/gen/error.rs
@@ -34,16 +34,16 @@ fn gen_definition<T>(
         .iter()
         .map(|validator| match validator {
             FloatValidator::Min(_) => {
-                quote!(TooSmall,)
+                quote!(MinViolated,)
             }
             FloatValidator::Max(_) => {
-                quote!(TooBig,)
+                quote!(MaxViolated,)
             }
             FloatValidator::Predicate(_) => {
-                quote!(Invalid,)
+                quote!(PredicateViolated,)
             }
             FloatValidator::Finite => {
-                quote!(NotFinite,)
+                quote!(FiniteViolated,)
             }
         })
         .collect();
@@ -61,16 +61,16 @@ fn gen_impl_display_trait<T>(
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
         FloatValidator::Min(_) => quote! {
-             #error_type_name::TooSmall => write!(f, "too small")
+             #error_type_name::MinViolated => write!(f, "too small")
         },
         FloatValidator::Max(_) => quote! {
-             #error_type_name::TooBig=> write!(f, "too big")
+             #error_type_name::MaxViolated=> write!(f, "too big")
         },
         FloatValidator::Predicate(_) => quote! {
-             #error_type_name::Invalid => write!(f, "invalid")
+             #error_type_name::PredicateViolated => write!(f, "invalid")
         },
         FloatValidator::Finite => quote! {
-             #error_type_name::NotFinite => write!(f, "not finite")
+             #error_type_name::FiniteViolated => write!(f, "not finite")
         },
     });
 

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -68,28 +68,28 @@ where
                 FloatValidator::Max(max) => {
                     quote!(
                         if val > #max {
-                            return Err(#error_name::TooBig);
+                            return Err(#error_name::MaxViolated);
                         }
                     )
                 }
                 FloatValidator::Min(min) => {
                     quote!(
                         if val < #min {
-                            return Err(#error_name::TooSmall);
+                            return Err(#error_name::MinViolated);
                         }
                     )
                 }
                 FloatValidator::Predicate(custom_is_valid_fn) => {
                     quote!(
                         if !(#custom_is_valid_fn)(&val) {
-                            return Err(#error_name::Invalid);
+                            return Err(#error_name::PredicateViolated);
                         }
                     )
                 }
                 FloatValidator::Finite => {
                     quote!(
                         if !val.is_finite() {
-                            return Err(#error_name::NotFinite);
+                            return Err(#error_name::FiniteViolated);
                         }
                     )
                 }

--- a/nutype_macros/src/integer/gen/error.rs
+++ b/nutype_macros/src/integer/gen/error.rs
@@ -33,13 +33,13 @@ fn gen_definition<T>(
         .iter()
         .map(|validator| match validator {
             IntegerValidator::Min(_) => {
-                quote!(TooSmall,)
+                quote!(MinViolated,)
             }
             IntegerValidator::Max(_) => {
-                quote!(TooBig,)
+                quote!(MaxViolated,)
             }
             IntegerValidator::Predicate(_) => {
-                quote!(Invalid,)
+                quote!(PredicateViolated,)
             }
         })
         .collect();
@@ -57,13 +57,13 @@ fn gen_impl_display_trait<T>(
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
         IntegerValidator::Min(_) => quote! {
-             #error_type_name::TooSmall => write!(f, "too small")
+             #error_type_name::MinViolated => write!(f, "too small")
         },
         IntegerValidator::Max(_) => quote! {
-             #error_type_name::TooBig=> write!(f, "too big")
+             #error_type_name::MaxViolated=> write!(f, "too big")
         },
         IntegerValidator::Predicate(_) => quote! {
-             #error_type_name::Invalid => write!(f, "invalid")
+             #error_type_name::PredicateViolated => write!(f, "invalid")
         },
     });
 

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -66,21 +66,21 @@ where
                 IntegerValidator::Max(max) => {
                     quote!(
                         if val > #max {
-                            return Err(#error_name::TooBig);
+                            return Err(#error_name::MaxViolated);
                         }
                     )
                 }
                 IntegerValidator::Min(min) => {
                     quote!(
                         if val < #min {
-                            return Err(#error_name::TooSmall);
+                            return Err(#error_name::MinViolated);
                         }
                     )
                 }
                 IntegerValidator::Predicate(custom_is_valid_fn) => {
                     quote!(
                         if !(#custom_is_valid_fn)(&val) {
-                            return Err(#error_name::Invalid);
+                            return Err(#error_name::PredicateViolated);
                         }
                     )
                 }

--- a/nutype_macros/src/string/gen/error.rs
+++ b/nutype_macros/src/string/gen/error.rs
@@ -32,19 +32,19 @@ fn gen_definition(error_type_name: &ErrorTypeName, validators: &[StringValidator
         .iter()
         .map(|validator| match validator {
             StringValidator::CharLenMax(_len) => {
-                quote!(TooLong,)
+                quote!(CharLenMaxViolated,)
             }
             StringValidator::CharLenMin(_len) => {
-                quote!(TooShort,)
+                quote!(CharLenMinViolated,)
             }
             StringValidator::NotEmpty => {
-                quote!(Empty,)
+                quote!(NotEmptyViolated,)
             }
             StringValidator::Predicate(_) => {
-                quote!(Invalid,)
+                quote!(PredicateViolated,)
             }
             StringValidator::Regex(_) => {
-                quote!(RegexMismatch,)
+                quote!(RegexViolated,)
             }
         })
         .collect();
@@ -62,19 +62,19 @@ fn gen_impl_display_trait(
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
         StringValidator::CharLenMax(_len) => quote! {
-             #error_type_name::TooLong => write!(f, "too long")
+             #error_type_name::CharLenMaxViolated => write!(f, "too long")
         },
         StringValidator::CharLenMin(_len) => quote! {
-             #error_type_name::TooShort => write!(f, "too short")
+             #error_type_name::CharLenMinViolated => write!(f, "too short")
         },
         StringValidator::NotEmpty => quote! {
-             #error_type_name::Empty => write!(f, "empty")
+             #error_type_name::NotEmptyViolated => write!(f, "empty")
         },
         StringValidator::Predicate(_) => quote! {
-             #error_type_name::Invalid => write!(f, "invalid")
+             #error_type_name::PredicateViolated => write!(f, "invalid")
         },
         StringValidator::Regex(_) => quote! {
-             #error_type_name::RegexMismatch => write!(f, "regex mismatch")
+             #error_type_name::RegexViolated => write!(f, "regex violated")
         },
     });
 

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -89,7 +89,7 @@ impl GenerateNewtype for StringNewtype {
                     requires_chars_count = true;
                     quote!(
                         if chars_count > #max_len {
-                            return Err(#error_name::TooLong);
+                            return Err(#error_name::CharLenMaxViolated);
                         }
                     )
                 }
@@ -97,21 +97,21 @@ impl GenerateNewtype for StringNewtype {
                     requires_chars_count = true;
                     quote!(
                         if chars_count < #min_len {
-                            return Err(#error_name::TooShort);
+                            return Err(#error_name::CharLenMinViolated);
                         }
                     )
                 }
                 StringValidator::NotEmpty => {
                     quote!(
                         if val.is_empty() {
-                            return Err(#error_name::Empty);
+                            return Err(#error_name::NotEmptyViolated);
                         }
                     )
                 }
                 StringValidator::Predicate(typed_custom_function) => {
                     quote!(
                         if !(#typed_custom_function)(&val) {
-                            return Err(#error_name::Invalid);
+                            return Err(#error_name::PredicateViolated);
                         }
                     )
                 }
@@ -125,7 +125,7 @@ impl GenerateNewtype for StringNewtype {
                                     static ref __NUTYPE_REGEX__: ::regex::Regex = ::regex::Regex::new(#regex_str_lit).expect("Nutype failed to a build a regex");
                                 }
                                 if !__NUTYPE_REGEX__.is_match(&val) {
-                                    return Err(#error_name::RegexMismatch);
+                                    return Err(#error_name::RegexViolated);
                                 }
                             )
 
@@ -133,7 +133,7 @@ impl GenerateNewtype for StringNewtype {
                         RegexDef::Path(regex_path) => {
                             quote!(
                                 if !#regex_path.is_match(&val) {
-                                    return Err(#error_name::RegexMismatch);
+                                    return Err(#error_name::RegexViolated);
                                 }
                             )
                         }

--- a/test_suite/tests/float.rs
+++ b/test_suite/tests/float.rs
@@ -59,7 +59,7 @@ mod validators {
         )]
         struct Age(f32);
 
-        assert_eq!(Age::new(17.0).unwrap_err(), AgeError::TooSmall);
+        assert_eq!(Age::new(17.0).unwrap_err(), AgeError::MinViolated);
         assert_eq!(Age::new(18.0).unwrap().into_inner(), 18.0);
     }
 
@@ -71,7 +71,7 @@ mod validators {
         )]
         struct Age(f32);
 
-        assert_eq!(Age::new(100.0).unwrap_err(), AgeError::TooBig);
+        assert_eq!(Age::new(100.0).unwrap_err(), AgeError::MaxViolated);
         assert_eq!(Age::new(99.0).unwrap().into_inner(), 99.0);
     }
 
@@ -83,8 +83,8 @@ mod validators {
         )]
         struct Age(f32);
 
-        assert_eq!(Age::new(17.9).unwrap_err(), AgeError::TooSmall);
-        assert_eq!(Age::new(99.1).unwrap_err(), AgeError::TooBig);
+        assert_eq!(Age::new(17.9).unwrap_err(), AgeError::MinViolated);
+        assert_eq!(Age::new(99.1).unwrap_err(), AgeError::MaxViolated);
         assert_eq!(Age::new(25.0).unwrap().into_inner(), 25.0);
     }
 
@@ -94,12 +94,12 @@ mod validators {
         struct Dist(f64);
 
         // invalid
-        assert_eq!(Dist::new(f64::INFINITY), Err(DistError::NotFinite));
-        assert_eq!(Dist::new(f64::NEG_INFINITY), Err(DistError::NotFinite));
-        assert_eq!(Dist::new(f64::NAN), Err(DistError::NotFinite));
-        assert_eq!(Dist::new(-1.0 / 0.0), Err(DistError::NotFinite));
-        assert_eq!(Dist::new(1.0 / 0.0), Err(DistError::NotFinite));
-        assert_eq!(Dist::new(0.0 / 0.0), Err(DistError::NotFinite));
+        assert_eq!(Dist::new(f64::INFINITY), Err(DistError::FiniteViolated));
+        assert_eq!(Dist::new(f64::NEG_INFINITY), Err(DistError::FiniteViolated));
+        assert_eq!(Dist::new(f64::NAN), Err(DistError::FiniteViolated));
+        assert_eq!(Dist::new(-1.0 / 0.0), Err(DistError::FiniteViolated));
+        assert_eq!(Dist::new(1.0 / 0.0), Err(DistError::FiniteViolated));
+        assert_eq!(Dist::new(0.0 / 0.0), Err(DistError::FiniteViolated));
 
         // valid
         assert_eq!(Dist::new(12.345).unwrap().into_inner(), 12.345);
@@ -115,9 +115,9 @@ mod validators {
         struct Dist(f32);
 
         // invalid
-        assert_eq!(Dist::new(-1.0 / 0.0), Err(DistError::NotFinite));
-        assert_eq!(Dist::new(1.0 / 0.0), Err(DistError::NotFinite));
-        assert_eq!(Dist::new(0.0 / 0.0), Err(DistError::NotFinite));
+        assert_eq!(Dist::new(-1.0 / 0.0), Err(DistError::FiniteViolated));
+        assert_eq!(Dist::new(1.0 / 0.0), Err(DistError::FiniteViolated));
+        assert_eq!(Dist::new(0.0 / 0.0), Err(DistError::FiniteViolated));
 
         // valid
         assert_eq!(Dist::new(12.345).unwrap().into_inner(), 12.345);
@@ -133,8 +133,8 @@ mod validators {
             #[nutype(validate(predicate = |&c: &f32| (0.0..=100.0).contains(&c) ), derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef))]
             pub struct Cent(f32);
 
-            assert_eq!(Cent::new(-0.1), Err(CentError::Invalid));
-            assert_eq!(Cent::new(100.1), Err(CentError::Invalid));
+            assert_eq!(Cent::new(-0.1), Err(CentError::PredicateViolated));
+            assert_eq!(Cent::new(100.1), Err(CentError::PredicateViolated));
             assert_eq!(Cent::new(100.0).unwrap().into_inner(), 100.0);
             assert_eq!(Cent::new(0.0).unwrap().into_inner(), 0.0);
         }
@@ -144,8 +144,8 @@ mod validators {
             #[nutype(validate(predicate = |&c| (0.0..=100.0).contains(&c) ), derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef))]
             pub struct Cent(f32);
 
-            assert_eq!(Cent::new(-0.1), Err(CentError::Invalid));
-            assert_eq!(Cent::new(100.1), Err(CentError::Invalid));
+            assert_eq!(Cent::new(-0.1), Err(CentError::PredicateViolated));
+            assert_eq!(Cent::new(100.1), Err(CentError::PredicateViolated));
             assert_eq!(Cent::new(100.0).unwrap().into_inner(), 100.0);
             assert_eq!(Cent::new(0.0).unwrap().into_inner(), 0.0);
         }
@@ -159,8 +159,8 @@ mod validators {
             #[nutype(validate(predicate = is_cent_valid), derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef))]
             pub struct Cent(f32);
 
-            assert_eq!(Cent::new(-0.1), Err(CentError::Invalid));
-            assert_eq!(Cent::new(100.1), Err(CentError::Invalid));
+            assert_eq!(Cent::new(-0.1), Err(CentError::PredicateViolated));
+            assert_eq!(Cent::new(100.1), Err(CentError::PredicateViolated));
             assert_eq!(Cent::new(100.0).unwrap().into_inner(), 100.0);
             assert_eq!(Cent::new(0.0).unwrap().into_inner(), 0.0);
         }
@@ -174,7 +174,7 @@ mod validators {
         )]
         struct Age(f64);
 
-        assert_eq!(Age::try_from(17.9).unwrap_err(), AgeError::TooSmall);
+        assert_eq!(Age::try_from(17.9).unwrap_err(), AgeError::MinViolated);
         assert_eq!(Age::try_from(18.0).unwrap().into_inner(), 18.0);
     }
 
@@ -214,8 +214,8 @@ mod types {
         #[nutype(validate(min = 0.0, max = 100), derive(Debug, PartialEq))]
         pub struct Width(f32);
 
-        assert_eq!(Width::new(-0.0001), Err(WidthError::TooSmall));
-        assert_eq!(Width::new(100.0001), Err(WidthError::TooBig));
+        assert_eq!(Width::new(-0.0001), Err(WidthError::MinViolated));
+        assert_eq!(Width::new(100.0001), Err(WidthError::MaxViolated));
         assert!(Width::new(0.0).is_ok());
         assert!(Width::new(100.0).is_ok());
     }
@@ -225,8 +225,8 @@ mod types {
         #[nutype(validate(min = 0.0, max = 100), derive(Debug, PartialEq))]
         pub struct Width(f64);
 
-        assert_eq!(Width::new(-0.0001), Err(WidthError::TooSmall));
-        assert_eq!(Width::new(100.0001), Err(WidthError::TooBig));
+        assert_eq!(Width::new(-0.0001), Err(WidthError::MinViolated));
+        assert_eq!(Width::new(100.0001), Err(WidthError::MaxViolated));
 
         assert_eq!(Width::new(0.0).unwrap().into_inner(), 0.0);
 
@@ -243,8 +243,8 @@ mod types {
         )]
         pub struct Balance(f64);
 
-        assert_eq!(Balance::new(-300.0), Err(BalanceError::TooSmall));
-        assert_eq!(Balance::new(-4.0), Err(BalanceError::TooBig));
+        assert_eq!(Balance::new(-300.0), Err(BalanceError::MinViolated));
+        assert_eq!(Balance::new(-4.0), Err(BalanceError::MaxViolated));
 
         let balance = Balance::new(-100.24).unwrap();
         assert_eq!(balance.into_inner(), -100.24);
@@ -360,7 +360,7 @@ mod traits {
         assert_eq!(dist.into_inner(), 12.34);
 
         let error = Dist::try_from(12.35).unwrap_err();
-        assert_eq!(error, DistError::TooBig);
+        assert_eq!(error, DistError::MaxViolated);
     }
 
     #[test]

--- a/test_suite/tests/integer.rs
+++ b/test_suite/tests/integer.rs
@@ -64,7 +64,7 @@ mod validators {
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(17).unwrap_err(), AgeError::TooSmall);
+        assert_eq!(Age::new(17).unwrap_err(), AgeError::MinViolated);
         assert_eq!(Age::new(18).unwrap().into_inner(), 18);
     }
 
@@ -78,7 +78,7 @@ mod validators {
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(100).unwrap_err(), AgeError::TooBig);
+        assert_eq!(Age::new(100).unwrap_err(), AgeError::MaxViolated);
         assert_eq!(Age::new(99).unwrap().into_inner(), 99);
     }
 
@@ -92,8 +92,8 @@ mod validators {
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(17).unwrap_err(), AgeError::TooSmall);
-        assert_eq!(Age::new(100).unwrap_err(), AgeError::TooBig);
+        assert_eq!(Age::new(17).unwrap_err(), AgeError::MinViolated);
+        assert_eq!(Age::new(100).unwrap_err(), AgeError::MaxViolated);
         assert_eq!(Age::new(25).unwrap().into_inner(), 25);
     }
 
@@ -106,8 +106,8 @@ mod validators {
             #[nutype(validate(predicate = |c: &i32| (0..=100).contains(c) ), derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash))]
             pub struct Cent(i32);
 
-            assert_eq!(Cent::new(-10), Err(CentError::Invalid));
-            assert_eq!(Cent::new(101), Err(CentError::Invalid));
+            assert_eq!(Cent::new(-10), Err(CentError::PredicateViolated));
+            assert_eq!(Cent::new(101), Err(CentError::PredicateViolated));
             assert_eq!(Cent::new(100).unwrap().into_inner(), 100);
         }
 
@@ -116,8 +116,8 @@ mod validators {
             #[nutype(validate(predicate = |c| (0..=100).contains(c) ), derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash))]
             pub struct Cent(i32);
 
-            assert_eq!(Cent::new(-10), Err(CentError::Invalid));
-            assert_eq!(Cent::new(101), Err(CentError::Invalid));
+            assert_eq!(Cent::new(-10), Err(CentError::PredicateViolated));
+            assert_eq!(Cent::new(101), Err(CentError::PredicateViolated));
             assert_eq!(Cent::new(100).unwrap().into_inner(), 100);
         }
 
@@ -133,8 +133,8 @@ mod validators {
             )]
             pub struct Cent(i32);
 
-            assert_eq!(Cent::new(-1), Err(CentError::Invalid));
-            assert_eq!(Cent::new(101), Err(CentError::Invalid));
+            assert_eq!(Cent::new(-1), Err(CentError::PredicateViolated));
+            assert_eq!(Cent::new(101), Err(CentError::PredicateViolated));
             assert_eq!(Cent::new(100).unwrap().into_inner(), 100);
         }
     }
@@ -149,7 +149,7 @@ mod validators {
         )]
         struct Age(u8);
 
-        assert_eq!(Age::try_from(17).unwrap_err(), AgeError::TooSmall);
+        assert_eq!(Age::try_from(17).unwrap_err(), AgeError::MinViolated);
         assert_eq!(Age::try_from(18).unwrap().into_inner(), 18);
     }
 
@@ -196,8 +196,8 @@ mod types {
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(17), Err(AgeError::TooSmall));
-        assert_eq!(Age::new(100), Err(AgeError::TooBig));
+        assert_eq!(Age::new(17), Err(AgeError::MinViolated));
+        assert_eq!(Age::new(100), Err(AgeError::MaxViolated));
         assert!(Age::new(20).is_ok());
     }
 
@@ -220,8 +220,8 @@ mod types {
         )]
         struct Age(u16);
 
-        assert_eq!(Age::new(17), Err(AgeError::TooSmall));
-        assert_eq!(Age::new(65001), Err(AgeError::TooBig));
+        assert_eq!(Age::new(17), Err(AgeError::MinViolated));
+        assert_eq!(Age::new(65001), Err(AgeError::MaxViolated));
         assert!(Age::new(20).is_ok());
     }
 
@@ -235,8 +235,8 @@ mod types {
         )]
         struct Amount(u32);
 
-        assert_eq!(Amount::new(17), Err(AmountError::TooSmall));
-        assert_eq!(Amount::new(100_001), Err(AmountError::TooBig));
+        assert_eq!(Amount::new(17), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(100_001), Err(AmountError::MaxViolated));
         assert!(Amount::new(100_000).is_ok());
     }
 
@@ -250,8 +250,11 @@ mod types {
         )]
         struct Amount(u64);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
-        assert_eq!(Amount::new(18446744073709551001), Err(AmountError::TooBig));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(
+            Amount::new(18446744073709551001),
+            Err(AmountError::MaxViolated)
+        );
         assert!(Amount::new(1000).is_ok());
     }
 
@@ -265,10 +268,10 @@ mod types {
         )]
         struct Amount(u128);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
         assert_eq!(
             Amount::new(170141183460469231731687303715884105829),
-            Err(AmountError::TooBig)
+            Err(AmountError::MaxViolated)
         );
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(170141183460469231731687303715884105828).is_ok());
@@ -288,8 +291,8 @@ mod types {
         #[nutype(validate(min = -20, max = 100), derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash))]
         struct Offset(i8);
 
-        assert_eq!(Offset::new(-21), Err(OffsetError::TooSmall));
-        assert_eq!(Offset::new(101), Err(OffsetError::TooBig));
+        assert_eq!(Offset::new(-21), Err(OffsetError::MinViolated));
+        assert_eq!(Offset::new(101), Err(OffsetError::MaxViolated));
         assert!(Offset::new(100).is_ok());
         assert!(Offset::new(-20).is_ok());
         assert!(Offset::new(0).is_ok());
@@ -305,8 +308,8 @@ mod types {
         )]
         struct Amount(i16);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
-        assert_eq!(Amount::new(32_001), Err(AmountError::TooBig));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(32_001), Err(AmountError::MaxViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(32_000).is_ok());
     }
@@ -322,8 +325,8 @@ mod types {
 
         struct Amount(i32);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
-        assert_eq!(Amount::new(320_001), Err(AmountError::TooBig));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(320_001), Err(AmountError::MaxViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(320_000).is_ok());
 
@@ -340,8 +343,8 @@ mod types {
         )]
         pub struct Balance(i32);
 
-        assert_eq!(Balance::new(-300), Err(BalanceError::TooSmall));
-        assert_eq!(Balance::new(-4), Err(BalanceError::TooBig));
+        assert_eq!(Balance::new(-300), Err(BalanceError::MinViolated));
+        assert_eq!(Balance::new(-4), Err(BalanceError::MaxViolated));
 
         let balance = Balance::new(-55).unwrap();
         assert_eq!(balance.into_inner(), -55);
@@ -355,8 +358,11 @@ mod types {
         )]
         struct Amount(i64);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
-        assert_eq!(Amount::new(8446744073709551001), Err(AmountError::TooBig));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(
+            Amount::new(8446744073709551001),
+            Err(AmountError::MaxViolated)
+        );
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(8446744073709551000).is_ok());
     }
@@ -369,10 +375,10 @@ mod types {
         )]
         struct Amount(i128);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
         assert_eq!(
             Amount::new(70141183460469231731687303715884105001),
-            Err(AmountError::TooBig)
+            Err(AmountError::MaxViolated)
         );
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(70141183460469231731687303715884105000).is_ok());
@@ -383,8 +389,8 @@ mod types {
         #[nutype(validate(min = 1000, max = 2000), derive(Debug, PartialEq))]
         struct Amount(usize);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
-        assert_eq!(Amount::new(2001), Err(AmountError::TooBig));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(2001), Err(AmountError::MaxViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(2000).is_ok());
     }
@@ -394,8 +400,8 @@ mod types {
         #[nutype(validate(min = 1000, max = 2000), derive(Debug, PartialEq))]
         struct Amount(isize);
 
-        assert_eq!(Amount::new(999), Err(AmountError::TooSmall));
-        assert_eq!(Amount::new(2001), Err(AmountError::TooBig));
+        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(2001), Err(AmountError::MaxViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(2000).is_ok());
     }
@@ -510,7 +516,7 @@ mod traits {
         assert_eq!(amount.into_inner(), 1000);
 
         let error = Amount::try_from(1001).unwrap_err();
-        assert_eq!(error, AmountError::TooBig);
+        assert_eq!(error, AmountError::MaxViolated);
     }
 
     #[test]


### PR DESCRIPTION
This fixes https://github.com/greyblake/nutype/issues/82

## Changes
Rename error variants to follow the following formular: `<ValidationRule>Violated`. This implies the following renames:
  * `TooShort` -> `CharLenMinViolated`
  * `TooLong` -> `CharLenMaxViolated`
  * `Empty` -> `NotEmptyViolated`
  * `RegexMismatch` -> `RegexViolated`
  * `Invalid` -> `PredicateViolated`
  * `TooBig` -> `MaxViolated`
  * `TooSmall` -> `MinViolated`
  * `NotFinite` -> `FiniteViolated`
