### PR TITLE
Rename max -> less_or_equal; min -> greater_or_equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 * [BREAKING] Validator `with` has been renamed to `predicate` to reflect the boolean nature of its range
 * [BREAKING] String validator `min_len` has been renamed to `char_len_min` to reflect that is based on UTF8 chars.
 * [BREAKING] String validator `max_len` has been renamed to `char_len_max` to reflect that is based on UTF8 chars.
-* [BREAKING] Rename error variants to follow the following formular: `<ValidationRule>Violated`. This implies the following renames:
+* [BREAKING] Rename numeric validator `max` to `less_or_equal`
+* [BREAKING] Rename numeric validator `min` to `greater_or_equal`
+* [BREAKING] Rename error variants to follow the following formula: `<ValidationRule>Violated`. This implies the following renames:
   * `TooShort` -> `CharLenMinViolated`
   * `TooLong` -> `CharLenMaxViolated`
   * `Empty` -> `NotEmptyViolated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
   * `Empty` -> `NotEmptyViolated`
   * `RegexMismatch` -> `RegexViolated`
   * `Invalid` -> `PredicateViolated`
-  * `TooBig` -> `MaxViolated`
-  * `TooSmall` -> `MinViolated`
+  * `TooBig` -> `LessOrEqualViolated`
+  * `TooSmall` -> `GreaterOrEqualViolated`
   * `NotFinite` -> `FiniteViolated`
 * Better error messages: in case of unknown attribute, validator or sanitizer the possible values are listed.
 

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -9,7 +9,10 @@ use nutype::nutype;
 )]
 pub struct Email(String);
 
-#[nutype(validate(min = 100, max = 1000), derive(Deref, FromStr))]
+#[nutype(
+    derive(Deref, FromStr),
+    validate(greater_or_equal = 10, less_or_equal = 1000)
+)]
 pub struct Number(i16);
 
 fn main() {

--- a/nutype/src/lib.rs
+++ b/nutype/src/lib.rs
@@ -178,11 +178,11 @@
 //!
 //! ### Integer validators
 //!
-//! | Validator   | Description         | Error variant       | Example                            |
-//! |-------------|---------------------|---------------------|------------------------------------|
-//! | `max`       | Maximum valid value | `MaxViolated`       | `max = 99`                         |
-//! | `min`       | Minimum valid value | `MinViolated`       | `min = 18`                         |
-//! | `predicate` | Custom validator    | `PredicateViolated` | `predicate = \|num\| num % 2 == 0` |
+//! | Validator           | Description           | Error variant             | Example                              |
+//! | ------------------- | --------------------- | ------------------------- | ------------------------------------ |
+//! | `less_or_equal`     | Maximum valid value   | `LessOrEqualViolated`     | `less_or_equal = 99`                 |
+//! | `greater_or_equal`  | Minimum valid value   | `GreaterOrEqualViolated`  | `greater_or_equal = 18`              |
+//! | `predicate`         | Custom predicate      | `PredicateViolated`       | `predicate = \|num\| num % 2 == 0`   |
 //!
 //! ### Integer derivable traits
 //!
@@ -203,12 +203,12 @@
 //!
 //! ### Float validators
 //!
-//! | Validator   | Description                    | Error variant       | Example                           |
-//! |-------------|--------------------------------|---------------------|-----------------------------------|
-//! | `max`       | Maximum valid value            | `MaxViolated`       | `max = 100.0`                     |
-//! | `min`       | Minimum valid value            | `MinViolated`       | `min = 0.0`                       |
-//! | `finite`    | Check against NaN and infinity | `FiniteViolated`    | `finite`                          |
-//! | `predicate` | Custom validator               | `PredicateViolated` | `predicate = \|val\| val != 50.0` |
+//! | Validator          | Description                      | Error variant            | Example                             |
+//! | ------------------ | -------------------------------- | ---------------------    | ----------------------------------- |
+//! | `less_or_equal`    | Maximum valid value              | `LessOrEqualViolated`    | `less_or_equal = 100.0`             |
+//! | `greater_or_equal` | Minimum valid value              | `GreaterOrEqualViolated` | `greater_or_equal = 0.0`            |
+//! | `finite`           | Check against NaN and infinity   | `FiniteViolated`         | `finite`                            |
+//! | `predicate`        | Custom predicate                 | `PredicateViolated`      | `predicate = \|val\| val != 50.0`   |
 //!
 //! ### Float derivable traits
 //!
@@ -379,11 +379,20 @@ mod tests {
 
     #[test]
     fn test_amount_example() {
-        #[nutype(validate(min = 100, max = 1_000), derive(Debug, PartialEq, TryFrom))]
+        #[nutype(
+            validate(greater_or_equal = 100, less_or_equal = 1_000),
+            derive(Debug, PartialEq, TryFrom)
+        )]
         pub struct Amount(u32);
 
-        assert_eq!(Amount::try_from(99), Err(AmountError::MinViolated));
-        assert_eq!(Amount::try_from(1_001), Err(AmountError::MaxViolated));
+        assert_eq!(
+            Amount::try_from(99),
+            Err(AmountError::GreaterOrEqualViolated)
+        );
+        assert_eq!(
+            Amount::try_from(1_001),
+            Err(AmountError::LessOrEqualViolated)
+        );
 
         assert_eq!(Amount::try_from(100).unwrap().into_inner(), 100);
     }

--- a/nutype_macros/src/common/parse/mod.rs
+++ b/nutype_macros/src/common/parse/mod.rs
@@ -109,7 +109,7 @@ impl<Sanitizer: Parse, Validator: Parse> Parse for ParseableAttributes<Sanitizer
                     let msg = concat!(
                         "`validate` must be used with parenthesis.\n",
                         "For example:\n\n",
-                        "    validate(max = 99)\n\n"
+                        "    validate(less_or_equal = 99)\n\n"
                     );
                     return Err(syn::Error::new(ident.span(), msg));
                 }

--- a/nutype_macros/src/float/gen/error.rs
+++ b/nutype_macros/src/float/gen/error.rs
@@ -33,11 +33,11 @@ fn gen_definition<T>(
     let error_variants: TokenStream = validators
         .iter()
         .map(|validator| match validator {
-            FloatValidator::Min(_) => {
-                quote!(MinViolated,)
+            FloatValidator::GreaterOrEqual(_) => {
+                quote!(GreaterOrEqualViolated,)
             }
-            FloatValidator::Max(_) => {
-                quote!(MaxViolated,)
+            FloatValidator::LessOrEqual(_) => {
+                quote!(LessOrEqualViolated,)
             }
             FloatValidator::Predicate(_) => {
                 quote!(PredicateViolated,)
@@ -60,11 +60,11 @@ fn gen_impl_display_trait<T>(
     validators: &[FloatValidator<T>],
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
-        FloatValidator::Min(_) => quote! {
-             #error_type_name::MinViolated => write!(f, "too small")
+        FloatValidator::GreaterOrEqual(_) => quote! {
+             #error_type_name::GreaterOrEqualViolated => write!(f, "too small")
         },
-        FloatValidator::Max(_) => quote! {
-             #error_type_name::MaxViolated=> write!(f, "too big")
+        FloatValidator::LessOrEqual(_) => quote! {
+             #error_type_name::LessOrEqualViolated=> write!(f, "too big")
         },
         FloatValidator::Predicate(_) => quote! {
              #error_type_name::PredicateViolated => write!(f, "invalid")

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -65,17 +65,17 @@ where
         let validations: TokenStream = validators
             .iter()
             .map(|validator| match validator {
-                FloatValidator::Max(max) => {
+                FloatValidator::LessOrEqual(max) => {
                     quote!(
                         if val > #max {
-                            return Err(#error_name::MaxViolated);
+                            return Err(#error_name::LessOrEqualViolated);
                         }
                     )
                 }
-                FloatValidator::Min(min) => {
+                FloatValidator::GreaterOrEqual(min) => {
                     quote!(
                         if val < #min {
-                            return Err(#error_name::MinViolated);
+                            return Err(#error_name::GreaterOrEqualViolated);
                         }
                     )
                 }

--- a/nutype_macros/src/float/models.rs
+++ b/nutype_macros/src/float/models.rs
@@ -21,8 +21,8 @@ pub type SpannedFloatSanitizer<T> = SpannedItem<FloatSanitizer<T>>;
 #[derive(Debug, Kinded)]
 #[kinded(display = "snake_case")]
 pub enum FloatValidator<T> {
-    Min(T),
-    Max(T),
+    GreaterOrEqual(T),
+    LessOrEqual(T),
     Predicate(TypedCustomFunction),
     Finite,
 }

--- a/nutype_macros/src/float/parse.rs
+++ b/nutype_macros/src/float/parse.rs
@@ -63,19 +63,19 @@ where
         let (kind, ident) = parse_validator_kind(input)?;
 
         match kind {
-            FloatValidatorKind::Min => {
+            FloatValidatorKind::GreaterOrEqual => {
                 let _eq: Token![=] = input.parse()?;
                 let (number, span) = parse_number::<T>(input)?;
                 Ok(SpannedFloatValidator {
-                    item: FloatValidator::Min(number as T),
+                    item: FloatValidator::GreaterOrEqual(number as T),
                     span,
                 })
             }
-            FloatValidatorKind::Max => {
+            FloatValidatorKind::LessOrEqual => {
                 let _eq: Token![=] = input.parse()?;
                 let (number, span) = parse_number::<T>(input)?;
                 Ok(SpannedFloatValidator {
-                    item: FloatValidator::Max(number as T),
+                    item: FloatValidator::LessOrEqual(number as T),
                     span,
                 })
             }

--- a/nutype_macros/src/float/validate.rs
+++ b/nutype_macros/src/float/validate.rs
@@ -46,25 +46,27 @@ where
         )
     })?;
 
-    // max VS min
-    let maybe_min = validators
+    // less_or_equal VS greater_or_equal
+    let maybe_greater_or_equal = validators
         .iter()
         .flat_map(|v| match &v.item {
-            FloatValidator::Min(ref min) => Some((v.span, min.clone())),
+            FloatValidator::GreaterOrEqual(ref min) => Some((v.span, min.clone())),
             _ => None,
         })
         .next();
-    let maybe_max = validators
+    let maybe_less_or_equal = validators
         .iter()
         .flat_map(|v| match v.item {
-            FloatValidator::Max(ref max) => Some((v.span, max.clone())),
+            FloatValidator::LessOrEqual(ref max) => Some((v.span, max.clone())),
             _ => None,
         })
         .next();
-    if let (Some((_min_span, min)), Some((max_span, max))) = (maybe_min, maybe_max) {
-        if min > max {
-            let msg = "`min` cannot be greater than `max`.\nSometimes we all need a little break.";
-            let err = syn::Error::new(max_span, msg);
+    if let (Some((_, greater_or_equal)), Some((span, less_or_equal))) =
+        (maybe_greater_or_equal, maybe_less_or_equal)
+    {
+        if greater_or_equal > less_or_equal {
+            let msg = "`greater_or_equal` cannot be greater than `less_or_equal`.\nSometimes we all need a little break.";
+            let err = syn::Error::new(span, msg);
             return Err(err);
         }
     }

--- a/nutype_macros/src/integer/gen/error.rs
+++ b/nutype_macros/src/integer/gen/error.rs
@@ -32,11 +32,11 @@ fn gen_definition<T>(
     let error_variants: TokenStream = validators
         .iter()
         .map(|validator| match validator {
-            IntegerValidator::Min(_) => {
-                quote!(MinViolated,)
+            IntegerValidator::GreaterOrEqual(_) => {
+                quote!(GreaterOrEqualViolated,)
             }
-            IntegerValidator::Max(_) => {
-                quote!(MaxViolated,)
+            IntegerValidator::LessOrEqual(_) => {
+                quote!(LessOrEqualViolated,)
             }
             IntegerValidator::Predicate(_) => {
                 quote!(PredicateViolated,)
@@ -56,11 +56,11 @@ fn gen_impl_display_trait<T>(
     validators: &[IntegerValidator<T>],
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
-        IntegerValidator::Min(_) => quote! {
-             #error_type_name::MinViolated => write!(f, "too small")
+        IntegerValidator::GreaterOrEqual(_) => quote! {
+             #error_type_name::GreaterOrEqualViolated => write!(f, "too small")
         },
-        IntegerValidator::Max(_) => quote! {
-             #error_type_name::MaxViolated=> write!(f, "too big")
+        IntegerValidator::LessOrEqual(_) => quote! {
+             #error_type_name::LessOrEqualViolated=> write!(f, "too big")
         },
         IntegerValidator::Predicate(_) => quote! {
              #error_type_name::PredicateViolated => write!(f, "invalid")

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -63,17 +63,17 @@ where
         let validations: TokenStream = validators
             .iter()
             .map(|validator| match validator {
-                IntegerValidator::Max(max) => {
+                IntegerValidator::LessOrEqual(max) => {
                     quote!(
                         if val > #max {
-                            return Err(#error_name::MaxViolated);
+                            return Err(#error_name::LessOrEqualViolated);
                         }
                     )
                 }
-                IntegerValidator::Min(min) => {
+                IntegerValidator::GreaterOrEqual(min) => {
                     quote!(
                         if val < #min {
-                            return Err(#error_name::MinViolated);
+                            return Err(#error_name::GreaterOrEqualViolated);
                         }
                     )
                 }

--- a/nutype_macros/src/integer/models.rs
+++ b/nutype_macros/src/integer/models.rs
@@ -21,8 +21,8 @@ pub type SpannedIntegerSanitizer<T> = SpannedItem<IntegerSanitizer<T>>;
 #[derive(Debug, Kinded)]
 #[kinded(display = "snake_case")]
 pub enum IntegerValidator<T> {
-    Min(T),
-    Max(T),
+    GreaterOrEqual(T),
+    LessOrEqual(T),
     Predicate(TypedCustomFunction),
 }
 

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -63,19 +63,19 @@ where
         let (kind, _ident) = parse_validator_kind(input)?;
 
         match kind {
-            IntegerValidatorKind::Min => {
+            IntegerValidatorKind::GreaterOrEqual => {
                 let _eq: Token![=] = input.parse()?;
                 let (number, span) = parse_number::<T>(input)?;
                 Ok(SpannedIntegerValidator {
-                    item: IntegerValidator::Min(number),
+                    item: IntegerValidator::GreaterOrEqual(number),
                     span,
                 })
             }
-            IntegerValidatorKind::Max => {
+            IntegerValidatorKind::LessOrEqual => {
                 let _eq: Token![=] = input.parse()?;
                 let (number, span) = parse_number::<T>(input)?;
                 Ok(SpannedIntegerValidator {
-                    item: IntegerValidator::Max(number),
+                    item: IntegerValidator::LessOrEqual(number),
                     span,
                 })
             }

--- a/nutype_macros/src/integer/validate.rs
+++ b/nutype_macros/src/integer/validate.rs
@@ -46,25 +46,27 @@ where
         )
     })?;
 
-    // max VS min
-    let maybe_min = validators
+    // less_or_equal VS greater_or_equal
+    let maybe_greater_or_equal = validators
         .iter()
         .flat_map(|v| match &v.item {
-            IntegerValidator::Min(ref min) => Some((v.span, min.clone())),
+            IntegerValidator::GreaterOrEqual(ref value) => Some((v.span, value.clone())),
             _ => None,
         })
         .next();
-    let maybe_max = validators
+    let maybe_less_or_equal = validators
         .iter()
         .flat_map(|v| match v.item {
-            IntegerValidator::Max(ref max) => Some((v.span, max.clone())),
+            IntegerValidator::LessOrEqual(ref value) => Some((v.span, value.clone())),
             _ => None,
         })
         .next();
-    if let (Some((_min_span, min)), Some((max_span, max))) = (maybe_min, maybe_max) {
-        if min > max {
-            let msg = "`min` cannot be greater than `max`.\nSometimes we all need a little break.";
-            let err = syn::Error::new(max_span, msg);
+    if let (Some((_, greater_or_equal)), Some((span, less_or_equal))) =
+        (maybe_greater_or_equal, maybe_less_or_equal)
+    {
+        if greater_or_equal > less_or_equal {
+            let msg = "`greater_or_equal` cannot be greater than `less_or_equal`.\nSometimes we all need a little break.";
+            let err = syn::Error::new(span, msg);
             return Err(err);
         }
     }

--- a/test_suite/tests/float.rs
+++ b/test_suite/tests/float.rs
@@ -54,37 +54,43 @@ mod validators {
     #[test]
     fn test_min() {
         #[nutype(
-            validate(min = 18.0),
+            validate(greater_or_equal = 18.0),
             derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef)
         )]
         struct Age(f32);
 
-        assert_eq!(Age::new(17.0).unwrap_err(), AgeError::MinViolated);
+        assert_eq!(
+            Age::new(17.0).unwrap_err(),
+            AgeError::GreaterOrEqualViolated
+        );
         assert_eq!(Age::new(18.0).unwrap().into_inner(), 18.0);
     }
 
     #[test]
     fn test_max() {
         #[nutype(
-            validate(max = 99.0),
+            validate(less_or_equal = 99.0),
             derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef)
         )]
         struct Age(f32);
 
-        assert_eq!(Age::new(100.0).unwrap_err(), AgeError::MaxViolated);
+        assert_eq!(Age::new(100.0).unwrap_err(), AgeError::LessOrEqualViolated);
         assert_eq!(Age::new(99.0).unwrap().into_inner(), 99.0);
     }
 
     #[test]
     fn test_min_and_max() {
         #[nutype(
-            validate(min = 18.0, max = 99.0),
+            validate(greater_or_equal = 18.0, less_or_equal = 99.0),
             derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef)
         )]
         struct Age(f32);
 
-        assert_eq!(Age::new(17.9).unwrap_err(), AgeError::MinViolated);
-        assert_eq!(Age::new(99.1).unwrap_err(), AgeError::MaxViolated);
+        assert_eq!(
+            Age::new(17.9).unwrap_err(),
+            AgeError::GreaterOrEqualViolated
+        );
+        assert_eq!(Age::new(99.1).unwrap_err(), AgeError::LessOrEqualViolated);
         assert_eq!(Age::new(25.0).unwrap().into_inner(), 25.0);
     }
 
@@ -169,12 +175,15 @@ mod validators {
     #[test]
     fn test_try_from_trait() {
         #[nutype(
-            validate(min = 18.0),
+            validate(greater_or_equal = 18.0),
             derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef)
         )]
         struct Age(f64);
 
-        assert_eq!(Age::try_from(17.9).unwrap_err(), AgeError::MinViolated);
+        assert_eq!(
+            Age::try_from(17.9).unwrap_err(),
+            AgeError::GreaterOrEqualViolated
+        );
         assert_eq!(Age::try_from(18.0).unwrap().into_inner(), 18.0);
     }
 
@@ -193,7 +202,7 @@ mod validators {
         #[test]
         fn test_error_display() {
             #[nutype(
-                validate(min = 0.0),
+                validate(greater_or_equal = 0.0),
                 derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef)
             )]
             struct Percentage(f64);
@@ -211,22 +220,28 @@ mod types {
 
     #[test]
     fn test_f32_validate() {
-        #[nutype(validate(min = 0.0, max = 100), derive(Debug, PartialEq))]
+        #[nutype(
+            validate(greater_or_equal = 0.0, less_or_equal = 100),
+            derive(Debug, PartialEq)
+        )]
         pub struct Width(f32);
 
-        assert_eq!(Width::new(-0.0001), Err(WidthError::MinViolated));
-        assert_eq!(Width::new(100.0001), Err(WidthError::MaxViolated));
+        assert_eq!(Width::new(-0.0001), Err(WidthError::GreaterOrEqualViolated));
+        assert_eq!(Width::new(100.0001), Err(WidthError::LessOrEqualViolated));
         assert!(Width::new(0.0).is_ok());
         assert!(Width::new(100.0).is_ok());
     }
 
     #[test]
     fn test_f64_validate() {
-        #[nutype(validate(min = 0.0, max = 100), derive(Debug, PartialEq))]
+        #[nutype(
+            validate(greater_or_equal = 0.0, less_or_equal = 100),
+            derive(Debug, PartialEq)
+        )]
         pub struct Width(f64);
 
-        assert_eq!(Width::new(-0.0001), Err(WidthError::MinViolated));
-        assert_eq!(Width::new(100.0001), Err(WidthError::MaxViolated));
+        assert_eq!(Width::new(-0.0001), Err(WidthError::GreaterOrEqualViolated));
+        assert_eq!(Width::new(100.0001), Err(WidthError::LessOrEqualViolated));
 
         assert_eq!(Width::new(0.0).unwrap().into_inner(), 0.0);
 
@@ -238,13 +253,16 @@ mod types {
     fn test_f64_negative() {
         #[nutype(
             sanitize(with = |n| n.clamp(-200.25, -5.0)),
-            validate(min = -100.25, max = -50.1),
+            validate(greater_or_equal = -100.25, less_or_equal = -50.1),
             derive(TryFrom, Debug, Clone, Copy, PartialEq, PartialOrd, FromStr, AsRef)
         )]
         pub struct Balance(f64);
 
-        assert_eq!(Balance::new(-300.0), Err(BalanceError::MinViolated));
-        assert_eq!(Balance::new(-4.0), Err(BalanceError::MaxViolated));
+        assert_eq!(
+            Balance::new(-300.0),
+            Err(BalanceError::GreaterOrEqualViolated)
+        );
+        assert_eq!(Balance::new(-4.0), Err(BalanceError::LessOrEqualViolated));
 
         let balance = Balance::new(-100.24).unwrap();
         assert_eq!(balance.into_inner(), -100.24);
@@ -288,7 +306,7 @@ mod traits {
     #[test]
     fn test_with_validaiton() {
         #[nutype(
-            validate(max = 100.0),
+            validate(less_or_equal = 100.0),
             derive(Debug, TryFrom, FromStr, Borrow, Clone, Copy)
         )]
         pub struct Dist(f64);
@@ -353,14 +371,14 @@ mod traits {
 
     #[test]
     fn test_trait_try_from() {
-        #[nutype(validate(max = 12.34), derive(Debug, TryFrom))]
+        #[nutype(validate(less_or_equal = 12.34), derive(Debug, TryFrom))]
         pub struct Dist(f64);
 
         let dist = Dist::try_from(12.34).unwrap();
         assert_eq!(dist.into_inner(), 12.34);
 
         let error = Dist::try_from(12.35).unwrap_err();
-        assert_eq!(error, DistError::MaxViolated);
+        assert_eq!(error, DistError::LessOrEqualViolated);
     }
 
     #[test]
@@ -380,7 +398,7 @@ mod traits {
 
     #[test]
     fn test_trait_from_str_with_validation() {
-        #[nutype(validate(max = 12.34), derive(Debug, FromStr))]
+        #[nutype(validate(less_or_equal = 12.34), derive(Debug, FromStr))]
         pub struct Dist(f64);
 
         // Happy path
@@ -541,7 +559,7 @@ mod traits {
     #[cfg(feature = "serde")]
     #[test]
     fn test_trait_deserialize_with_validation() {
-        #[nutype(validate(min = 13.3), derive(Deserialize))]
+        #[nutype(validate(greater_or_equal = 13.3), derive(Deserialize))]
         pub struct Offset(f32);
 
         {
@@ -574,7 +592,7 @@ mod traits {
 
         #[test]
         fn test_default_with_validation_when_valid() {
-            #[nutype(validate(max = 20.0), default = 13.0, derive(Default))]
+            #[nutype(validate(less_or_equal = 20.0), default = 13.0, derive(Default))]
             pub struct Number(f64);
 
             assert_eq!(Number::default().into_inner(), 13.0);
@@ -583,7 +601,7 @@ mod traits {
         #[test]
         #[should_panic(expected = "Default value for type Number is invalid")]
         fn test_default_with_validation_when_invalid() {
-            #[nutype(validate(max = 20.0), default = 20.1, derive(Default))]
+            #[nutype(validate(less_or_equal = 20.0), default = 20.1, derive(Default))]
             pub struct Number(f64);
 
             Number::default();
@@ -598,7 +616,7 @@ mod new_unchecked {
 
     #[test]
     fn test_new_unchecked() {
-        #[nutype(new_unchecked, validate(min = 50.0))]
+        #[nutype(new_unchecked, validate(greater_or_equal = 50.0))]
         pub struct Dist(f64);
 
         let dist = unsafe { Dist::new_unchecked(3.0) };

--- a/test_suite/tests/integer.rs
+++ b/test_suite/tests/integer.rs
@@ -57,43 +57,43 @@ mod validators {
     #[test]
     fn test_min() {
         #[nutype(
-            validate(min = 18),
+            validate(greater_or_equal = 18),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(17).unwrap_err(), AgeError::MinViolated);
+        assert_eq!(Age::new(17).unwrap_err(), AgeError::GreaterOrEqualViolated);
         assert_eq!(Age::new(18).unwrap().into_inner(), 18);
     }
 
     #[test]
     fn test_max() {
         #[nutype(
-            validate(max = 99),
+            validate(less_or_equal = 99),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(100).unwrap_err(), AgeError::MaxViolated);
+        assert_eq!(Age::new(100).unwrap_err(), AgeError::LessOrEqualViolated);
         assert_eq!(Age::new(99).unwrap().into_inner(), 99);
     }
 
     #[test]
     fn test_min_and_max() {
         #[nutype(
-            validate(min = 18, max = 99),
+            validate(greater_or_equal = 18, less_or_equal = 99),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(17).unwrap_err(), AgeError::MinViolated);
-        assert_eq!(Age::new(100).unwrap_err(), AgeError::MaxViolated);
+        assert_eq!(Age::new(17).unwrap_err(), AgeError::GreaterOrEqualViolated);
+        assert_eq!(Age::new(100).unwrap_err(), AgeError::LessOrEqualViolated);
         assert_eq!(Age::new(25).unwrap().into_inner(), 25);
     }
 
@@ -142,14 +142,17 @@ mod validators {
     #[test]
     fn test_try_from_trait() {
         #[nutype(
-            validate(min = 18),
+            validate(greater_or_equal = 18),
             derive(
                 TryFrom, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Age(u8);
 
-        assert_eq!(Age::try_from(17).unwrap_err(), AgeError::MinViolated);
+        assert_eq!(
+            Age::try_from(17).unwrap_err(),
+            AgeError::GreaterOrEqualViolated
+        );
         assert_eq!(Age::try_from(18).unwrap().into_inner(), 18);
     }
 
@@ -168,7 +171,7 @@ mod validators {
         #[test]
         fn test_error_display() {
             #[nutype(
-                validate(min = 18),
+                validate(greater_or_equal = 18),
                 derive(
                     TryFrom, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef,
                     Hash
@@ -191,13 +194,13 @@ mod types {
     fn test_u8_validate() {
         #[nutype(
             sanitize(with = |n| n.clamp(0, 200)),
-            validate(min = 18, max = 99),
+            validate(greater_or_equal = 18, less_or_equal = 99),
             derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash)
         )]
         struct Age(u8);
 
-        assert_eq!(Age::new(17), Err(AgeError::MinViolated));
-        assert_eq!(Age::new(100), Err(AgeError::MaxViolated));
+        assert_eq!(Age::new(17), Err(AgeError::GreaterOrEqualViolated));
+        assert_eq!(Age::new(100), Err(AgeError::LessOrEqualViolated));
         assert!(Age::new(20).is_ok());
     }
 
@@ -213,47 +216,47 @@ mod types {
     #[test]
     fn test_u16() {
         #[nutype(
-            validate(min = 18, max = 65000),
+            validate(greater_or_equal = 18, less_or_equal = 65000),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Age(u16);
 
-        assert_eq!(Age::new(17), Err(AgeError::MinViolated));
-        assert_eq!(Age::new(65001), Err(AgeError::MaxViolated));
+        assert_eq!(Age::new(17), Err(AgeError::GreaterOrEqualViolated));
+        assert_eq!(Age::new(65001), Err(AgeError::LessOrEqualViolated));
         assert!(Age::new(20).is_ok());
     }
 
     #[test]
     fn test_u32() {
         #[nutype(
-            validate(min = 1000, max = 100_000),
+            validate(greater_or_equal = 1000, less_or_equal = 100_000),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Amount(u32);
 
-        assert_eq!(Amount::new(17), Err(AmountError::MinViolated));
-        assert_eq!(Amount::new(100_001), Err(AmountError::MaxViolated));
+        assert_eq!(Amount::new(17), Err(AmountError::GreaterOrEqualViolated));
+        assert_eq!(Amount::new(100_001), Err(AmountError::LessOrEqualViolated));
         assert!(Amount::new(100_000).is_ok());
     }
 
     #[test]
     fn test_u64() {
         #[nutype(
-            validate(min = 1000, max = 18446744073709551000),
+            validate(greater_or_equal = 1000, less_or_equal = 18446744073709551000),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Amount(u64);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
         assert_eq!(
             Amount::new(18446744073709551001),
-            Err(AmountError::MaxViolated)
+            Err(AmountError::LessOrEqualViolated)
         );
         assert!(Amount::new(1000).is_ok());
     }
@@ -261,17 +264,20 @@ mod types {
     #[test]
     fn test_u128() {
         #[nutype(
-            validate(min = 1000, max = 170141183460469231731687303715884105828),
+            validate(
+                greater_or_equal = 1000,
+                less_or_equal = 170141183460469231731687303715884105828
+            ),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Amount(u128);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
         assert_eq!(
             Amount::new(170141183460469231731687303715884105829),
-            Err(AmountError::MaxViolated)
+            Err(AmountError::LessOrEqualViolated)
         );
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(170141183460469231731687303715884105828).is_ok());
@@ -288,11 +294,11 @@ mod types {
 
     #[test]
     fn test_i8_validate() {
-        #[nutype(validate(min = -20, max = 100), derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash))]
+        #[nutype(validate(greater_or_equal = -20, less_or_equal = 100), derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash))]
         struct Offset(i8);
 
-        assert_eq!(Offset::new(-21), Err(OffsetError::MinViolated));
-        assert_eq!(Offset::new(101), Err(OffsetError::MaxViolated));
+        assert_eq!(Offset::new(-21), Err(OffsetError::GreaterOrEqualViolated));
+        assert_eq!(Offset::new(101), Err(OffsetError::LessOrEqualViolated));
         assert!(Offset::new(100).is_ok());
         assert!(Offset::new(-20).is_ok());
         assert!(Offset::new(0).is_ok());
@@ -301,15 +307,15 @@ mod types {
     #[test]
     fn test_i16_validate() {
         #[nutype(
-            validate(min = 1000, max = 32_000),
+            validate(greater_or_equal = 1000, less_or_equal = 32_000),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
         )]
         struct Amount(i16);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
-        assert_eq!(Amount::new(32_001), Err(AmountError::MaxViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
+        assert_eq!(Amount::new(32_001), Err(AmountError::LessOrEqualViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(32_000).is_ok());
     }
@@ -317,7 +323,7 @@ mod types {
     #[test]
     fn test_i32_validate() {
         #[nutype(
-            validate(min = 1000, max = 320_000),
+            validate(greater_or_equal = 1000, less_or_equal = 320_000),
             derive(
                 Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash
             )
@@ -325,8 +331,8 @@ mod types {
 
         struct Amount(i32);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
-        assert_eq!(Amount::new(320_001), Err(AmountError::MaxViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
+        assert_eq!(Amount::new(320_001), Err(AmountError::LessOrEqualViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(320_000).is_ok());
 
@@ -338,13 +344,16 @@ mod types {
     fn test_i32_negative() {
         #[nutype(
             sanitize(with = |n| n.clamp(-200, -5)),
-            validate(min = -100, max = -50),
+            validate(greater_or_equal = -100, less_or_equal = -50),
             derive(TryFrom, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, FromStr, AsRef, Hash),
         )]
         pub struct Balance(i32);
 
-        assert_eq!(Balance::new(-300), Err(BalanceError::MinViolated));
-        assert_eq!(Balance::new(-4), Err(BalanceError::MaxViolated));
+        assert_eq!(
+            Balance::new(-300),
+            Err(BalanceError::GreaterOrEqualViolated)
+        );
+        assert_eq!(Balance::new(-4), Err(BalanceError::LessOrEqualViolated));
 
         let balance = Balance::new(-55).unwrap();
         assert_eq!(balance.into_inner(), -55);
@@ -353,15 +362,15 @@ mod types {
     #[test]
     fn test_i64_validate() {
         #[nutype(
-            validate(min = 1000, max = 8446744073709551000),
+            validate(greater_or_equal = 1000, less_or_equal = 8446744073709551000),
             derive(Debug, PartialEq)
         )]
         struct Amount(i64);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
         assert_eq!(
             Amount::new(8446744073709551001),
-            Err(AmountError::MaxViolated)
+            Err(AmountError::LessOrEqualViolated)
         );
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(8446744073709551000).is_ok());
@@ -370,15 +379,18 @@ mod types {
     #[test]
     fn test_i128_validate() {
         #[nutype(
-            validate(min = 1000, max = 70141183460469231731687303715884105000),
+            validate(
+                greater_or_equal = 1000,
+                less_or_equal = 70141183460469231731687303715884105000
+            ),
             derive(Debug, PartialEq)
         )]
         struct Amount(i128);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
         assert_eq!(
             Amount::new(70141183460469231731687303715884105001),
-            Err(AmountError::MaxViolated)
+            Err(AmountError::LessOrEqualViolated)
         );
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(70141183460469231731687303715884105000).is_ok());
@@ -386,22 +398,28 @@ mod types {
 
     #[test]
     fn test_usize_validate() {
-        #[nutype(validate(min = 1000, max = 2000), derive(Debug, PartialEq))]
+        #[nutype(
+            validate(greater_or_equal = 1000, less_or_equal = 2000),
+            derive(Debug, PartialEq)
+        )]
         struct Amount(usize);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
-        assert_eq!(Amount::new(2001), Err(AmountError::MaxViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
+        assert_eq!(Amount::new(2001), Err(AmountError::LessOrEqualViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(2000).is_ok());
     }
 
     #[test]
     fn test_isize_validate() {
-        #[nutype(validate(min = 1000, max = 2000), derive(Debug, PartialEq))]
+        #[nutype(
+            validate(greater_or_equal = 1000, less_or_equal = 2000),
+            derive(Debug, PartialEq)
+        )]
         struct Amount(isize);
 
-        assert_eq!(Amount::new(999), Err(AmountError::MinViolated));
-        assert_eq!(Amount::new(2001), Err(AmountError::MaxViolated));
+        assert_eq!(Amount::new(999), Err(AmountError::GreaterOrEqualViolated));
+        assert_eq!(Amount::new(2001), Err(AmountError::LessOrEqualViolated));
         assert!(Amount::new(1000).is_ok());
         assert!(Amount::new(2000).is_ok());
     }
@@ -444,7 +462,7 @@ mod traits {
     #[test]
     fn test_with_validaiton() {
         #[nutype(
-            validate(max = 1000),
+            validate(less_or_equal = 1000),
             derive(Debug, TryFrom, FromStr, Borrow, Clone, Copy)
         )]
         pub struct Number(u128);
@@ -509,14 +527,14 @@ mod traits {
 
     #[test]
     fn test_trait_try_from() {
-        #[nutype(validate(max = 1000), derive(Debug, TryFrom))]
+        #[nutype(validate(less_or_equal = 1000), derive(Debug, TryFrom))]
         pub struct Amount(i64);
 
         let amount = Amount::try_from(1000).unwrap();
         assert_eq!(amount.into_inner(), 1000);
 
         let error = Amount::try_from(1001).unwrap_err();
-        assert_eq!(error, AmountError::MaxViolated);
+        assert_eq!(error, AmountError::LessOrEqualViolated);
     }
 
     #[test]
@@ -536,7 +554,7 @@ mod traits {
 
     #[test]
     fn test_trait_from_str_with_validation() {
-        #[nutype(validate(max = 99), derive(Debug, FromStr))]
+        #[nutype(validate(less_or_equal = 99), derive(Debug, FromStr))]
         pub struct Age(isize);
 
         // Happy path
@@ -594,7 +612,7 @@ mod traits {
     #[cfg(feature = "serde")]
     #[test]
     fn test_trait_deserialize_with_validation() {
-        #[nutype(validate(min = 13), derive(Deserialize))]
+        #[nutype(validate(greater_or_equal = 13), derive(Deserialize))]
         pub struct Offset(i64);
 
         {
@@ -627,7 +645,7 @@ mod traits {
 
         #[test]
         fn test_default_with_validation_when_valid() {
-            #[nutype(validate(max = 20), default = 13, derive(Default))]
+            #[nutype(validate(less_or_equal = 20), default = 13, derive(Default))]
             pub struct Number(i8);
 
             assert_eq!(Number::default().into_inner(), 13);
@@ -636,7 +654,7 @@ mod traits {
         #[test]
         #[should_panic(expected = "Default value for type Number is invalid")]
         fn test_default_with_validation_when_invalid() {
-            #[nutype(validate(max = 20), default = 21, derive(Default))]
+            #[nutype(validate(less_or_equal = 20), default = 21, derive(Default))]
             pub struct Number(i16);
 
             Number::default();
@@ -651,7 +669,7 @@ mod new_unchecked {
 
     #[test]
     fn test_new_unchecked() {
-        #[nutype(new_unchecked, validate(min = 50))]
+        #[nutype(new_unchecked, validate(greater_or_equal = 50))]
         pub struct Dist(u32);
 
         let dist = unsafe { Dist::new_unchecked(3) };

--- a/test_suite/tests/ui/common/validate_without_parenthesis.stderr
+++ b/test_suite/tests/ui/common/validate_without_parenthesis.stderr
@@ -1,7 +1,7 @@
 error: `validate` must be used with parenthesis.
        For example:
 
-           validate(max = 99)
+           validate(less_or_equal = 99)
 
  --> tests/ui/common/validate_without_parenthesis.rs:3:10
   |

--- a/test_suite/tests/ui/float/validate/duplicated.rs
+++ b/test_suite/tests/ui/float/validate/duplicated.rs
@@ -1,6 +1,6 @@
 use nutype::nutype;
 
-#[nutype(validate(max = 0, max = 0))]
+#[nutype(validate(less_or_equal = 0, less_or_equal = 0))]
 pub struct Amount(f32);
 
 fn main() {}

--- a/test_suite/tests/ui/float/validate/duplicated.stderr
+++ b/test_suite/tests/ui/float/validate/duplicated.stderr
@@ -1,6 +1,6 @@
-error: Duplicated validator `max`.
+error: Duplicated validator `less_or_equal`.
        You're a great engineer, but don't forget to take care of yourself!
- --> tests/ui/float/validate/duplicated.rs:3:34
+ --> tests/ui/float/validate/duplicated.rs:3:54
   |
-3 | #[nutype(validate(max = 0, max = 0))]
-  |                                  ^
+3 | #[nutype(validate(less_or_equal = 0, less_or_equal = 0))]
+  |                                                      ^

--- a/test_suite/tests/ui/float/validate/greater_or_equal_vs_less_or_equal.rs
+++ b/test_suite/tests/ui/float/validate/greater_or_equal_vs_less_or_equal.rs
@@ -1,0 +1,6 @@
+use nutype::nutype;
+
+#[nutype(validate(less_or_equal = 0, greater_or_equal = 20))]
+pub struct Amount(f64);
+
+fn main() {}

--- a/test_suite/tests/ui/float/validate/greater_or_equal_vs_less_or_equal.stderr
+++ b/test_suite/tests/ui/float/validate/greater_or_equal_vs_less_or_equal.stderr
@@ -1,0 +1,6 @@
+error: `greater_or_equal` cannot be greater than `less_or_equal`.
+       Sometimes we all need a little break.
+ --> tests/ui/float/validate/greater_or_equal_vs_less_or_equal.rs:3:35
+  |
+3 | #[nutype(validate(less_or_equal = 0, greater_or_equal = 20))]
+  |                                   ^

--- a/test_suite/tests/ui/float/validate/min_vs_max.rs
+++ b/test_suite/tests/ui/float/validate/min_vs_max.rs
@@ -1,6 +1,0 @@
-use nutype::nutype;
-
-#[nutype(validate(max = 0, min = 20))]
-pub struct Amount(f64);
-
-fn main() {}

--- a/test_suite/tests/ui/float/validate/min_vs_max.stderr
+++ b/test_suite/tests/ui/float/validate/min_vs_max.stderr
@@ -1,6 +1,0 @@
-error: `min` cannot be greater than `max`.
-       Sometimes we all need a little break.
- --> tests/ui/float/validate/min_vs_max.rs:3:25
-  |
-3 | #[nutype(validate(max = 0, min = 20))]
-  |                         ^

--- a/test_suite/tests/ui/float/validate/unknown.stderr
+++ b/test_suite/tests/ui/float/validate/unknown.stderr
@@ -1,5 +1,5 @@
 error: Unknown validator `meaningful`.
-       Possible values are `min`, `max`, `predicate`, `finite`.
+       Possible values are `greater_or_equal`, `less_or_equal`, `predicate`, `finite`.
  --> tests/ui/float/validate/unknown.rs:3:19
   |
 3 | #[nutype(validate(meaningful))]

--- a/test_suite/tests/ui/float/visibility/private_error.rs
+++ b/test_suite/tests/ui/float/visibility/private_error.rs
@@ -1,7 +1,7 @@
 mod encapsulated {
     use nutype::nutype;
 
-    #[nutype(validate(min = 0.0, max = 100.0))]
+    #[nutype(validate(greater_or_equal = 0.0, less_or_equal = 100.0))]
     struct Percentage(f32);
 }
 

--- a/test_suite/tests/ui/float/visibility/private_error.stderr
+++ b/test_suite/tests/ui/float/visibility/private_error.stderr
@@ -7,11 +7,11 @@ error[E0603]: enum import `PercentageError` is private
 note: the enum import `PercentageError` is defined here...
  --> tests/ui/float/visibility/private_error.rs:4:5
   |
-4 |     #[nutype(validate(min = 0.0, max = 100.0))]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     #[nutype(validate(greater_or_equal = 0.0, less_or_equal = 100.0))]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...and refers to the enum `PercentageError` which is defined here
  --> tests/ui/float/visibility/private_error.rs:4:5
   |
-4 |     #[nutype(validate(min = 0.0, max = 100.0))]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider importing it directly
+4 |     #[nutype(validate(greater_or_equal = 0.0, less_or_equal = 100.0))]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider importing it directly
   = note: this error originates in the attribute macro `nutype` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test_suite/tests/ui/integer/derive/default.rs
+++ b/test_suite/tests/ui/integer/derive/default.rs
@@ -1,7 +1,7 @@
 use nutype::nutype;
 
 #[nutype(
-    validate(max = 1024),
+    validate(less_or_equal = 1024),
     derive(Default)
 )]
 pub struct Count(i32);

--- a/test_suite/tests/ui/integer/derive/default.stderr
+++ b/test_suite/tests/ui/integer/derive/default.stderr
@@ -2,7 +2,7 @@ error: custom attribute panicked
  --> tests/ui/integer/derive/default.rs:3:1
   |
 3 | / #[nutype(
-4 | |     validate(max = 1024),
+4 | |     validate(less_or_equal = 1024),
 5 | |     derive(Default)
 6 | | )]
   | |__^

--- a/test_suite/tests/ui/integer/validate/duplicated.rs
+++ b/test_suite/tests/ui/integer/validate/duplicated.rs
@@ -1,6 +1,6 @@
 use nutype::nutype;
 
-#[nutype(validate(max = 0, max = 0))]
+#[nutype(validate(less_or_equal = 0, less_or_equal = 0))]
 pub struct Amount(i64);
 
 fn main() {}

--- a/test_suite/tests/ui/integer/validate/duplicated.stderr
+++ b/test_suite/tests/ui/integer/validate/duplicated.stderr
@@ -1,6 +1,6 @@
-error: Duplicated validator `max`.
+error: Duplicated validator `less_or_equal`.
        You're a great engineer, but don't forget to take care of yourself!
- --> tests/ui/integer/validate/duplicated.rs:3:34
+ --> tests/ui/integer/validate/duplicated.rs:3:54
   |
-3 | #[nutype(validate(max = 0, max = 0))]
-  |                                  ^
+3 | #[nutype(validate(less_or_equal = 0, less_or_equal = 0))]
+  |                                                      ^

--- a/test_suite/tests/ui/integer/validate/greater_or_equal_vs_less_or_equal.rs
+++ b/test_suite/tests/ui/integer/validate/greater_or_equal_vs_less_or_equal.rs
@@ -1,0 +1,6 @@
+use nutype::nutype;
+
+#[nutype(validate(less_or_equal = 0, greater_or_equal = 20))]
+pub struct Amount(i64);
+
+fn main() {}

--- a/test_suite/tests/ui/integer/validate/greater_or_equal_vs_less_or_equal.stderr
+++ b/test_suite/tests/ui/integer/validate/greater_or_equal_vs_less_or_equal.stderr
@@ -1,0 +1,6 @@
+error: `greater_or_equal` cannot be greater than `less_or_equal`.
+       Sometimes we all need a little break.
+ --> tests/ui/integer/validate/greater_or_equal_vs_less_or_equal.rs:3:35
+  |
+3 | #[nutype(validate(less_or_equal = 0, greater_or_equal = 20))]
+  |                                   ^

--- a/test_suite/tests/ui/integer/validate/min_vs_max.rs
+++ b/test_suite/tests/ui/integer/validate/min_vs_max.rs
@@ -1,6 +1,0 @@
-use nutype::nutype;
-
-#[nutype(validate(max = 0, min = 20))]
-pub struct Amount(i64);
-
-fn main() {}

--- a/test_suite/tests/ui/integer/validate/min_vs_max.stderr
+++ b/test_suite/tests/ui/integer/validate/min_vs_max.stderr
@@ -1,6 +1,0 @@
-error: `min` cannot be greater than `max`.
-       Sometimes we all need a little break.
- --> tests/ui/integer/validate/min_vs_max.rs:3:25
-  |
-3 | #[nutype(validate(max = 0, min = 20))]
-  |                         ^

--- a/test_suite/tests/ui/integer/validate/unknown.stderr
+++ b/test_suite/tests/ui/integer/validate/unknown.stderr
@@ -1,5 +1,5 @@
 error: Unknown validator `meaningful`.
-       Possible values are `min`, `max`, `predicate`.
+       Possible values are `greater_or_equal`, `less_or_equal`, `predicate`.
  --> tests/ui/integer/validate/unknown.rs:3:19
   |
 3 | #[nutype(validate(meaningful))]

--- a/test_suite/tests/ui/integer/visibility/private_error.rs
+++ b/test_suite/tests/ui/integer/visibility/private_error.rs
@@ -1,7 +1,7 @@
 mod encapsulated {
     use nutype::nutype;
 
-    #[nutype(validate(min = 0, max = 100))]
+    #[nutype(validate(greater_or_equal = 0, less_or_equal = 100))]
     struct Percentage(i32);
 }
 

--- a/test_suite/tests/ui/integer/visibility/private_error.stderr
+++ b/test_suite/tests/ui/integer/visibility/private_error.stderr
@@ -7,11 +7,11 @@ error[E0603]: enum import `PercentageError` is private
 note: the enum import `PercentageError` is defined here...
  --> tests/ui/integer/visibility/private_error.rs:4:5
   |
-4 |     #[nutype(validate(min = 0, max = 100))]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 |     #[nutype(validate(greater_or_equal = 0, less_or_equal = 100))]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...and refers to the enum `PercentageError` which is defined here
  --> tests/ui/integer/visibility/private_error.rs:4:5
   |
-4 |     #[nutype(validate(min = 0, max = 100))]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider importing it directly
+4 |     #[nutype(validate(greater_or_equal = 0, less_or_equal = 100))]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider importing it directly
   = note: this error originates in the attribute macro `nutype` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Changes

Rename the following validators for integer and float:
* `max` -> `less_or_equal`
* `min` -> `greater_or_equal`