### PR TITLE
initial error message reformat

### DIFF
--- a/nutype_macros/src/any/gen/error.rs
+++ b/nutype_macros/src/any/gen/error.rs
@@ -12,7 +12,7 @@ use crate::{
 pub fn gen_validation_error_type(type_name: &TypeName, validators: &[AnyValidator]) -> TokenStream {
     let error_type_name = gen_error_type_name(type_name);
     let definition = gen_definition(&error_type_name, validators);
-    let impl_display_trait = gen_impl_display_trait(&error_type_name, validators);
+    let impl_display_trait = gen_impl_display_trait(type_name, &error_type_name, validators);
     let impl_error_trait = gen_impl_error_trait(&error_type_name);
 
     quote! {
@@ -43,12 +43,13 @@ fn gen_definition(error_type_name: &ErrorTypeName, validators: &[AnyValidator]) 
 }
 
 fn gen_impl_display_trait(
+    type_name: &TypeName,
     error_type_name: &ErrorTypeName,
     validators: &[AnyValidator],
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
         AnyValidator::Predicate(_) => quote! {
-             #error_type_name::PredicateViolated => write!(f, "invalid")
+             #error_type_name::PredicateViolated => write!(f, "{} failed the predicate test.", stringify!(#type_name))
         },
     });
 

--- a/nutype_macros/src/integer/gen/error.rs
+++ b/nutype_macros/src/integer/gen/error.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 
 use super::super::models::IntegerValidator;
 use crate::common::{
@@ -7,13 +7,13 @@ use crate::common::{
     models::{ErrorTypeName, TypeName},
 };
 
-pub fn gen_validation_error_type<T>(
+pub fn gen_validation_error_type<T: ToTokens>(
     type_name: &TypeName,
     validators: &[IntegerValidator<T>],
 ) -> TokenStream {
     let error_type_name = gen_error_type_name(type_name);
     let definition = gen_definition(&error_type_name, validators);
-    let impl_display_trait = gen_impl_display_trait(&error_type_name, validators);
+    let impl_display_trait = gen_impl_display_trait(type_name, &error_type_name, validators);
     let impl_error_trait = gen_impl_error_trait(&error_type_name);
 
     quote! {
@@ -58,25 +58,26 @@ fn gen_definition<T>(
     }
 }
 
-fn gen_impl_display_trait<T>(
+fn gen_impl_display_trait<T: ToTokens>(
+    type_name: &TypeName,
     error_type_name: &ErrorTypeName,
     validators: &[IntegerValidator<T>],
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
-        IntegerValidator::Greater(_) => quote! {
-             #error_type_name::GreaterViolated => write!(f, "too small")
+        IntegerValidator::Greater(val) => quote! {
+             #error_type_name::GreaterViolated => write!(f, "{} is too small. The value must be greater than {:#?}.", stringify!(#type_name), #val)
         },
-        IntegerValidator::GreaterOrEqual(_) => quote! {
-             #error_type_name::GreaterOrEqualViolated => write!(f, "too small")
+        IntegerValidator::GreaterOrEqual(val) => quote! {
+             #error_type_name::GreaterOrEqualViolated => write!(f, "{} is too small. The value must be greater or equal to {:#?}.", stringify!(#type_name), #val)
         },
-        IntegerValidator::Less(_) => quote! {
-             #error_type_name::LessViolated=> write!(f, "too big")
+        IntegerValidator::Less(val) => quote! {
+             #error_type_name::LessViolated=> write!(f, "{} is too big. The value must be less than {:#?}.", stringify!(#type_name), #val)
         },
-        IntegerValidator::LessOrEqual(_) => quote! {
-             #error_type_name::LessOrEqualViolated=> write!(f, "too big")
+        IntegerValidator::LessOrEqual(val) => quote! {
+             #error_type_name::LessOrEqualViolated=> write!(f, "{} is too big. The value must be less or equal to {:#?}.", stringify!(#type_name), #val)
         },
         IntegerValidator::Predicate(_) => quote! {
-             #error_type_name::PredicateViolated => write!(f, "invalid")
+             #error_type_name::PredicateViolated => write!(f, "{} failed the predicate test.", stringify!(#type_name))
         },
     });
 


### PR DESCRIPTION
This PR is aimed to rewrite the pretty print for vaildator error types to include details about the bounds and the name of a newtype, addressing #105 