### PR TITLE
Support for generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v0.x.x - 2024-xx-xx
+
+* Support newtypes with generics
+
+
 ### v0.4.2 - 2024-04-07
 
 * Support `no_std` ( the dependency needs to be declared as `nutype = { default-features = false }` )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_generics"
+version = "0.1.0"
+dependencies = [
+ "nutype",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ members = [
     "examples/serde_complex",
     "examples/string_bounded_len",
     "examples/string_regex_email",
-    "examples/string_arbitrary",
+    "examples/string_arbitrary", "examples/any_generics",
 ]

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,10 +1,9 @@
 use nutype::nutype;
 
 #[nutype(
-    validate(predicate = |v| v),
-    derive(Default),
-    default = true
+    sanitize(with = |v| v),
+    validate(predicate = |v| v.len() > 0)
 )]
-pub struct TestData(bool);
+struct NonEmptyVec<T>(Vec<T>);
 
 fn main() {}

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,9 +1,9 @@
 use nutype::nutype;
+use std::borrow::Cow;
 
 #[nutype(
-    sanitize(with = |v| v),
-    validate(predicate = |v| !v.is_empty() )
+    validate(predicate = |s| s.len() >= 3),
 )]
-struct NonEmptyVec<T>(Vec<T>);
+struct Clarabelle<'a>(Cow<'a, str>);
 
 fn main() {}

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,9 +1,10 @@
 use nutype::nutype;
 use std::borrow::Cow;
 
-#[nutype(
-    validate(predicate = |s| s.len() >= 3),
-)]
+#[nutype(derive(Debug, Display))]
 struct Clarabelle<'a>(Cow<'a, str>);
 
-fn main() {}
+fn main() {
+    let clarabelle = Clarabelle::new(Cow::Borrowed("Clarabelle"));
+    assert_eq!(clarabelle.to_string(), "Clarabelle");
+}

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,10 +1,10 @@
 use nutype::nutype;
 use std::borrow::Cow;
 
-#[nutype(derive(Debug, Display))]
+#[nutype(derive(Into))]
 struct Clarabelle<'a>(Cow<'a, str>);
 
 fn main() {
-    let clarabelle = Clarabelle::new(Cow::Borrowed("Clarabelle"));
-    assert_eq!(clarabelle.to_string(), "Clarabelle");
+    // let clarabelle = Clarabelle::new(Cow::Borrowed("Clarabelle"));
+    // assert_eq!(clarabelle.to_string(), "Clarabelle");
 }

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -2,7 +2,7 @@ use nutype::nutype;
 
 #[nutype(
     sanitize(with = |v| v),
-    validate(predicate = |v| v.len() > 0)
+    validate(predicate = |v| !v.is_empty() )
 )]
 struct NonEmptyVec<T>(Vec<T>);
 

--- a/examples/any_generics/Cargo.toml
+++ b/examples/any_generics/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "any_generics"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nutype = { path = "../../nutype" }

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -7,7 +7,32 @@ use std::borrow::Cow;
 )]
 struct NotEmpty<T>(Vec<T>);
 
-#[nutype(derive(Debug, Display))]
+#[nutype(derive(
+    Debug,
+    Display,
+    Clone,
+    // Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+
+    // TODO
+    // AsRef,
+
+    Into,
+    From,
+    // Deref,
+    // Borrow,
+    // FromStr,
+    // TryFrom,
+    // Default,
+
+    // SerdeSerialize,
+    // SerdeDeserialize,
+    // ArbitraryArbitrary,
+))]
 struct Clarabelle<'b>(Cow<'b, str>);
 
 fn main() {

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -23,7 +23,7 @@ struct NotEmpty<T>(Vec<T>);
 
     Into,
     From,
-    // Deref,
+    Deref,
     // Borrow,
     // FromStr,
     // TryFrom,

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -24,7 +24,7 @@ struct NotEmpty<T>(Vec<T>);
     Into,
     From,
     Deref,
-    // Borrow,
+    Borrow,
     // FromStr,
     // TryFrom,
     // Default,

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -11,27 +11,23 @@ struct NotEmpty<T>(Vec<T>);
     Debug,
     Display,
     Clone,
-    // Copy,
     PartialEq,
     Eq,
     PartialOrd,
     Ord,
     Hash,
-
-    // TODO
-    // AsRef,
-    // FromStr,
-
     Into,
     From,
     Deref,
     Borrow,
+    // TODO
+    // AsRef,
+    // FromStr,
     // TryFrom,
     // Default,
-
-    // SerdeSerialize,
-    // SerdeDeserialize,
-    // ArbitraryArbitrary,
+    // Serialize,
+    // Deserialize,
+    // Arbitrary,
 ))]
 struct Clarabelle<'b>(Cow<'b, str>);
 

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -20,12 +20,12 @@ struct NotEmpty<T>(Vec<T>);
 
     // TODO
     // AsRef,
+    // FromStr,
 
     Into,
     From,
     Deref,
     Borrow,
-    // FromStr,
     // TryFrom,
     // Default,
 

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -9,7 +9,7 @@ struct NotEmpty<T>(Vec<T>);
 
 #[nutype(
     derive(Debug),
-    validate(predicate = |s| s.len() > 3),
+    validate(predicate = |s| s.len() >= 3),
 )]
 struct Clarabelle<'b>(Cow<'b, str>);
 

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -1,0 +1,30 @@
+use nutype::nutype;
+use std::borrow::Cow;
+
+#[nutype(
+    validate(predicate = |vec| !vec.is_empty()),
+    derive(Debug),
+)]
+struct NotEmpty<T>(Vec<T>);
+
+#[nutype(
+    derive(Debug),
+    validate(predicate = |s| s.len() > 3),
+)]
+struct Clarabelle<'b>(Cow<'b, str>);
+
+fn main() {
+    {
+        let v = NotEmpty::new(vec![1, 2, 3]).unwrap();
+        assert_eq!(v.into_inner(), vec![1, 2, 3]);
+    }
+    {
+        let err = NotEmpty::<i32>::new(vec![]).unwrap_err();
+        assert_eq!(err, NotEmptyError::PredicateViolated);
+    }
+
+    {
+        let c1 = Clarabelle::new(Cow::Borrowed("Muu")).unwrap();
+        assert_eq!(c1.into_inner(), Cow::Borrowed("Muu"));
+    }
+}

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 )]
 struct NotEmpty<T>(Vec<T>);
 
-#[nutype(derive(Debug))]
+#[nutype(derive(Debug, Display))]
 struct Clarabelle<'b>(Cow<'b, str>);
 
 fn main() {
@@ -21,7 +21,7 @@ fn main() {
     }
 
     {
-        let c1 = Clarabelle::new(Cow::Borrowed("Muu"));
-        assert_eq!(c1.into_inner(), Cow::Borrowed("Muu"));
+        let muu = Clarabelle::new(Cow::Borrowed("Muu"));
+        assert_eq!(muu.to_string(), "Muu");
     }
 }

--- a/examples/any_generics/src/main.rs
+++ b/examples/any_generics/src/main.rs
@@ -7,10 +7,7 @@ use std::borrow::Cow;
 )]
 struct NotEmpty<T>(Vec<T>);
 
-#[nutype(
-    derive(Debug),
-    validate(predicate = |s| s.len() >= 3),
-)]
+#[nutype(derive(Debug))]
 struct Clarabelle<'b>(Cow<'b, str>);
 
 fn main() {
@@ -24,7 +21,7 @@ fn main() {
     }
 
     {
-        let c1 = Clarabelle::new(Cow::Borrowed("Muu")).unwrap();
+        let c1 = Clarabelle::new(Cow::Borrowed("Muu"));
         assert_eq!(c1.into_inner(), Cow::Borrowed("Muu"));
     }
 }

--- a/nutype_macros/src/any/gen/mod.rs
+++ b/nutype_macros/src/any/gen/mod.rs
@@ -53,7 +53,7 @@ impl GenerateNewtype for AnyNewtype {
             .collect();
 
         quote!(
-            fn sanitize(mut value: #inner_type) -> #inner_type {
+            fn __sanitize__(mut value: #inner_type) -> #inner_type {
                 #transformations
                 value
             }
@@ -88,7 +88,7 @@ impl GenerateNewtype for AnyNewtype {
             .collect();
 
         quote!(
-            fn validate<'a>(val: &'a #inner_type) -> ::core::result::Result<(), #error_name> {
+            fn __validate__<'a>(val: &'a #inner_type) -> ::core::result::Result<(), #error_name> {
                 #validations
                 Ok(())
             }

--- a/nutype_macros/src/any/gen/mod.rs
+++ b/nutype_macros/src/any/gen/mod.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::parse_quote;
+use syn::{parse_quote, Generics};
 
 use crate::common::{
     gen::{
@@ -117,6 +117,7 @@ impl GenerateNewtype for AnyNewtype {
 
     fn gen_traits(
         type_name: &TypeName,
+        generics: &Generics,
         inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,
@@ -125,6 +126,7 @@ impl GenerateNewtype for AnyNewtype {
     ) -> Result<GeneratedTraits, syn::Error> {
         gen_traits(
             type_name,
+            generics,
             inner_type,
             maybe_error_type_name,
             traits,

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -107,6 +107,7 @@ enum AnyIrregularTrait {
 
 pub fn gen_traits(
     type_name: &TypeName,
+    generics: &syn::Generics,
     inner_type: &AnyInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
     traits: HashSet<AnyDeriveTrait>,
@@ -126,6 +127,7 @@ pub fn gen_traits(
 
     let implement_traits = gen_implemented_traits(
         type_name,
+        generics,
         inner_type,
         maybe_error_type_name,
         irregular_traits,
@@ -141,6 +143,7 @@ pub fn gen_traits(
 
 fn gen_implemented_traits(
     type_name: &TypeName,
+    generics: &syn::Generics,
     inner_type: &AnyInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
     impl_traits: Vec<AnyIrregularTrait>,
@@ -153,7 +156,7 @@ fn gen_implemented_traits(
             AnyIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, inner_type)),
             AnyIrregularTrait::From => Ok(gen_impl_trait_from(type_name, inner_type)),
             AnyIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, inner_type.clone())),
-            AnyIrregularTrait::Display => Ok(gen_impl_trait_display(type_name)),
+            AnyIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             AnyIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, inner_type)),
             AnyIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
             AnyIrregularTrait::FromStr => Ok(

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -154,7 +154,7 @@ fn gen_implemented_traits(
         .iter()
         .map(|t| match t {
             AnyIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, inner_type)),
-            AnyIrregularTrait::From => Ok(gen_impl_trait_from(type_name, inner_type)),
+            AnyIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
             AnyIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type.clone())),
             AnyIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             AnyIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, inner_type)),

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -158,7 +158,7 @@ fn gen_implemented_traits(
             AnyIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type.clone())),
             AnyIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             AnyIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, inner_type)),
-            AnyIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
+            AnyIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             AnyIrregularTrait::FromStr => Ok(
                 gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref())
             ),

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -163,7 +163,7 @@ fn gen_implemented_traits(
                 gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref())
             ),
             AnyIrregularTrait::TryFrom => Ok(
-                gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref())
+                gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name.as_ref())
             ),
             AnyIrregularTrait::Default => match maybe_default_value {
                 Some(ref default_value) => {

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -155,7 +155,7 @@ fn gen_implemented_traits(
         .map(|t| match t {
             AnyIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, inner_type)),
             AnyIrregularTrait::From => Ok(gen_impl_trait_from(type_name, inner_type)),
-            AnyIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, inner_type.clone())),
+            AnyIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type.clone())),
             AnyIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             AnyIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, inner_type)),
             AnyIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -157,7 +157,7 @@ fn gen_implemented_traits(
             AnyIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
             AnyIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type.clone())),
             AnyIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
-            AnyIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, inner_type)),
+            AnyIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, inner_type)),
             AnyIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
             AnyIrregularTrait::FromStr => Ok(
                 gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref())

--- a/nutype_macros/src/common/gen/mod.rs
+++ b/nutype_macros/src/common/gen/mod.rs
@@ -182,6 +182,7 @@ pub trait GenerateNewtype {
 
     fn gen_traits(
         type_name: &TypeName,
+        generics: &Generics,
         inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,
@@ -345,6 +346,7 @@ pub trait GenerateNewtype {
             implement_traits,
         } = Self::gen_traits(
             &type_name,
+            &generics,
             &inner_type,
             maybe_error_type_name,
             traits,

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -120,9 +120,13 @@ pub fn gen_impl_trait_display(type_name: &TypeName, generics: &Generics) -> Toke
     }
 }
 
-pub fn gen_impl_trait_borrow(type_name: &TypeName, borrowed_type: impl ToTokens) -> TokenStream {
+pub fn gen_impl_trait_borrow(
+    type_name: &TypeName,
+    generics: &Generics,
+    borrowed_type: impl ToTokens,
+) -> TokenStream {
     quote! {
-        impl ::core::borrow::Borrow<#borrowed_type> for #type_name {
+        impl #generics ::core::borrow::Borrow<#borrowed_type> for #type_name #generics {
             #[inline]
             fn borrow(&self) -> &#borrowed_type {
                 &self.0

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -52,7 +52,11 @@ where
     }
 }
 
-pub fn gen_impl_trait_into(type_name: &TypeName, inner_type: impl Into<InnerType>) -> TokenStream {
+pub fn gen_impl_trait_into(
+    type_name: &TypeName,
+    generics: &Generics,
+    inner_type: impl Into<InnerType>,
+) -> TokenStream {
     let inner_type: InnerType = inner_type.into();
 
     // NOTE: We're getting blank implementation of
@@ -60,9 +64,9 @@ pub fn gen_impl_trait_into(type_name: &TypeName, inner_type: impl Into<InnerType
     // by implementing
     //     From<Type> for Inner
     quote! {
-        impl ::core::convert::From<#type_name> for #inner_type {
+        impl #generics ::core::convert::From<#type_name #generics> for #inner_type {
             #[inline]
-            fn from(value: #type_name) -> Self {
+            fn from(value: #type_name #generics) -> Self {
                 value.into_inner()
             }
         }

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -84,9 +84,13 @@ pub fn gen_impl_trait_as_ref(type_name: &TypeName, inner_type: impl ToTokens) ->
     }
 }
 
-pub fn gen_impl_trait_deref(type_name: &TypeName, inner_type: impl ToTokens) -> TokenStream {
+pub fn gen_impl_trait_deref(
+    type_name: &TypeName,
+    generics: &Generics,
+    inner_type: impl ToTokens,
+) -> TokenStream {
     quote! {
-        impl ::core::ops::Deref for #type_name {
+        impl #generics ::core::ops::Deref for #type_name #generics {
             type Target = #inner_type;
 
             #[inline]
@@ -130,7 +134,7 @@ pub fn gen_impl_trait_borrow(type_name: &TypeName, borrowed_type: impl ToTokens)
 pub fn gen_impl_trait_from(
     type_name: &TypeName,
     generics: &Generics,
-    inner_type: impl ToTokens
+    inner_type: impl ToTokens,
 ) -> TokenStream {
     quote! {
         impl #generics ::core::convert::From<#inner_type> for #type_name #generics {

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -152,6 +152,7 @@ pub fn gen_impl_trait_from(
 
 pub fn gen_impl_trait_try_from(
     type_name: &TypeName,
+    generics: &Generics,
     inner_type: impl ToTokens,
     maybe_error_type_name: Option<&ErrorTypeName>,
 ) -> TokenStream {
@@ -160,11 +161,11 @@ pub fn gen_impl_trait_try_from(
             // The case when there are validation
             //
             quote! {
-                impl ::core::convert::TryFrom<#inner_type> for #type_name {
+                impl #generics ::core::convert::TryFrom<#inner_type> for #type_name #generics {
                     type Error = #error_type_name;
 
                     #[inline]
-                    fn try_from(raw_value: #inner_type) -> Result<#type_name, Self::Error> {
+                    fn try_from(raw_value: #inner_type) -> Result<#type_name #generics, Self::Error> {
                         Self::new(raw_value)
                     }
                 }
@@ -174,11 +175,11 @@ pub fn gen_impl_trait_try_from(
             // The case when there are no validation
             //
             quote! {
-                impl ::core::convert::TryFrom<#inner_type> for #type_name {
+                impl #generics ::core::convert::TryFrom<#inner_type> for #type_name #generics {
                     type Error = ::core::convert::Infallible;
 
                     #[inline]
-                    fn try_from(raw_value: #inner_type) -> Result<#type_name, Self::Error> {
+                    fn try_from(raw_value: #inner_type) -> Result<#type_name #generics, Self::Error> {
                         Ok(Self::new(raw_value))
                     }
                 }

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -127,9 +127,13 @@ pub fn gen_impl_trait_borrow(type_name: &TypeName, borrowed_type: impl ToTokens)
     }
 }
 
-pub fn gen_impl_trait_from(type_name: &TypeName, inner_type: impl ToTokens) -> TokenStream {
+pub fn gen_impl_trait_from(
+    type_name: &TypeName,
+    generics: &Generics,
+    inner_type: impl ToTokens
+) -> TokenStream {
     quote! {
-        impl ::core::convert::From<#inner_type> for #type_name {
+        impl #generics ::core::convert::From<#inner_type> for #type_name #generics {
             #[inline]
             fn from(raw_value: #inner_type) -> Self {
                 Self::new(raw_value)

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::Generics;
 
 use crate::common::models::{ErrorTypeName, InnerType, TypeName};
 
@@ -92,9 +93,9 @@ pub fn gen_impl_trait_deref(type_name: &TypeName, inner_type: impl ToTokens) -> 
     }
 }
 
-pub fn gen_impl_trait_display(type_name: &TypeName) -> TokenStream {
+pub fn gen_impl_trait_display(type_name: &TypeName, generics: &Generics) -> TokenStream {
     quote! {
-        impl ::core::fmt::Display for #type_name {
+        impl #generics ::core::fmt::Display for #type_name #generics {
             #[inline]
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 // A tiny wrapper function with trait boundary that improves error reporting.

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -1,6 +1,7 @@
 use kinded::Kinded;
 use std::ops::Add;
 use std::{collections::HashSet, fmt::Debug};
+use syn::Generics;
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
@@ -158,6 +159,7 @@ pub struct Meta {
     pub inner_type: InnerType,
     pub vis: syn::Visibility,
     pub doc_attrs: Vec<Attribute>,
+    pub generics: Generics,
 }
 
 impl Meta {
@@ -167,10 +169,12 @@ impl Meta {
             type_name,
             inner_type,
             vis,
+            generics,
         } = self;
         let typed_meta = TypedMeta {
             doc_attrs,
             type_name,
+            generics,
             attrs,
             vis,
         };
@@ -189,6 +193,7 @@ pub struct TypedMeta {
 
     pub vis: syn::Visibility,
     pub doc_attrs: Vec<Attribute>,
+    pub generics: Generics,
 }
 
 /// Validated model, that represents precisely what needs to be generated.
@@ -342,6 +347,7 @@ pub struct GenerateParams<IT, Trait, Guard> {
     pub traits: HashSet<Trait>,
     pub vis: syn::Visibility,
     pub type_name: TypeName,
+    pub generics: Generics,
     pub guard: Guard,
     pub new_unchecked: NewUnchecked,
     pub maybe_default_value: Option<syn::Expr>,
@@ -381,6 +387,7 @@ pub trait Newtype {
             type_name,
             attrs,
             vis,
+            generics,
         } = typed_meta;
         let Attributes {
             guard,
@@ -394,6 +401,7 @@ pub trait Newtype {
             traits,
             vis,
             type_name,
+            generics,
             guard,
             new_unchecked,
             maybe_default_value,

--- a/nutype_macros/src/common/parse/meta.rs
+++ b/nutype_macros/src/common/parse/meta.rs
@@ -22,7 +22,7 @@ pub fn parse_meta(token_stream: TokenStream) -> Result<Meta, syn::Error> {
         data,
         vis,
         ident: type_name,
-        generics: _,
+        generics,
     } = input;
 
     let type_name = TypeName::new(type_name);
@@ -100,6 +100,7 @@ pub fn parse_meta(token_stream: TokenStream) -> Result<Meta, syn::Error> {
     Ok(Meta {
         doc_attrs,
         type_name,
+        generics,
         inner_type,
         vis,
     })

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -56,7 +56,7 @@ where
             .collect();
 
         quote!(
-            fn sanitize(mut value: #inner_type) -> #inner_type {
+            fn __sanitize__(mut value: #inner_type) -> #inner_type {
                 #transformations
                 value
             }
@@ -119,7 +119,7 @@ where
             .collect();
 
         quote!(
-            fn validate(val: &#inner_type) -> core::result::Result<(), #error_name> {
+            fn __validate__(val: &#inner_type) -> core::result::Result<(), #error_name> {
                 let val = *val;
                 #validations
                 Ok(())

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::Generics;
 
 use self::error::gen_validation_error_type;
 use super::{
@@ -136,6 +137,7 @@ where
 
     fn gen_traits(
         type_name: &TypeName,
+        _generics: &Generics,
         inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -137,7 +137,7 @@ where
 
     fn gen_traits(
         type_name: &TypeName,
-        _generics: &Generics,
+        generics: &Generics,
         inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,
@@ -146,6 +146,7 @@ where
     ) -> Result<GeneratedTraits, syn::Error> {
         gen_traits(
             type_name,
+            generics,
             inner_type,
             maybe_error_type_name,
             maybe_default_value,

--- a/nutype_macros/src/float/gen/traits/mod.rs
+++ b/nutype_macros/src/float/gen/traits/mod.rs
@@ -177,7 +177,7 @@ fn gen_implemented_traits<T: ToTokens>(
             FloatIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
             FloatIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type)),
             FloatIrregularTrait::TryFrom => {
-                Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name.as_ref()))
             }
             FloatIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             FloatIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),

--- a/nutype_macros/src/float/gen/traits/mod.rs
+++ b/nutype_macros/src/float/gen/traits/mod.rs
@@ -123,6 +123,7 @@ impl ToTokens for FloatTransparentTrait {
 
 pub fn gen_traits<T: ToTokens>(
     type_name: &TypeName,
+    generics: &Generics,
     inner_type: &FloatInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
     maybe_default_value: Option<syn::Expr>,
@@ -142,6 +143,7 @@ pub fn gen_traits<T: ToTokens>(
 
     let implement_traits = gen_implemented_traits(
         type_name,
+        generics,
         inner_type,
         maybe_error_type_name,
         maybe_default_value,
@@ -157,6 +159,7 @@ pub fn gen_traits<T: ToTokens>(
 
 fn gen_implemented_traits<T: ToTokens>(
     type_name: &TypeName,
+    generics: &Generics,
     inner_type: &FloatInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
     maybe_default_value: Option<syn::Expr>,
@@ -171,13 +174,13 @@ fn gen_implemented_traits<T: ToTokens>(
             FloatIrregularTrait::FromStr => {
                 Ok(gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
-            FloatIrregularTrait::From => Ok(gen_impl_trait_from(type_name, inner_type)),
-            FloatIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, &Generics::default(), inner_type)),
+            FloatIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
+            FloatIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type)),
             FloatIrregularTrait::TryFrom => {
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
             FloatIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
-            FloatIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, &Generics::default())),
+            FloatIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             FloatIrregularTrait::Default => match maybe_default_value {
                 Some(ref default_value) => {
                     let has_validation = maybe_error_type_name.is_some();

--- a/nutype_macros/src/float/gen/traits/mod.rs
+++ b/nutype_macros/src/float/gen/traits/mod.rs
@@ -179,7 +179,7 @@ fn gen_implemented_traits<T: ToTokens>(
             FloatIrregularTrait::TryFrom => {
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
-            FloatIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
+            FloatIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             FloatIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             FloatIrregularTrait::Default => match maybe_default_value {
                 Some(ref default_value) => {

--- a/nutype_macros/src/float/gen/traits/mod.rs
+++ b/nutype_macros/src/float/gen/traits/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::Generics;
 
 use crate::{
     common::{
@@ -176,7 +177,7 @@ fn gen_implemented_traits<T: ToTokens>(
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
             FloatIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
-            FloatIrregularTrait::Display => Ok(gen_impl_trait_display(type_name)),
+            FloatIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, &Generics::default())),
             FloatIrregularTrait::Default => match maybe_default_value {
                 Some(ref default_value) => {
                     let has_validation = maybe_error_type_name.is_some();

--- a/nutype_macros/src/float/gen/traits/mod.rs
+++ b/nutype_macros/src/float/gen/traits/mod.rs
@@ -172,7 +172,7 @@ fn gen_implemented_traits<T: ToTokens>(
                 Ok(gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
             FloatIrregularTrait::From => Ok(gen_impl_trait_from(type_name, inner_type)),
-            FloatIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, inner_type)),
+            FloatIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, &Generics::default(), inner_type)),
             FloatIrregularTrait::TryFrom => {
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }

--- a/nutype_macros/src/float/gen/traits/mod.rs
+++ b/nutype_macros/src/float/gen/traits/mod.rs
@@ -170,7 +170,7 @@ fn gen_implemented_traits<T: ToTokens>(
         .iter()
         .map(|t| match t {
             FloatIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, inner_type)),
-            FloatIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, inner_type)),
+            FloatIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, inner_type)),
             FloatIrregularTrait::FromStr => {
                 Ok(gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref()))
             }

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::Generics;
 
 use self::{error::gen_validation_error_type, traits::gen_traits};
 use super::{
@@ -128,6 +129,7 @@ where
 
     fn gen_traits(
         type_name: &TypeName,
+        _generics: &Generics,
         inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -55,7 +55,7 @@ where
             .collect();
 
         quote!(
-            fn sanitize(mut value: #inner_type) -> #inner_type {
+            fn __sanitize__(mut value: #inner_type) -> #inner_type {
                 #transformations
                 value
             }
@@ -111,7 +111,7 @@ where
             .collect();
 
         quote!(
-            fn validate(val: &#inner_type) -> ::core::result::Result<(), #error_name> {
+            fn __validate__(val: &#inner_type) -> ::core::result::Result<(), #error_name> {
                 let val = *val;
                 #validations
                 Ok(())

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -129,7 +129,7 @@ where
 
     fn gen_traits(
         type_name: &TypeName,
-        _generics: &Generics,
+        generics: &Generics,
         inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,
@@ -138,6 +138,7 @@ where
     ) -> Result<GeneratedTraits, syn::Error> {
         gen_traits(
             type_name,
+            generics,
             inner_type,
             maybe_error_type_name,
             traits,

--- a/nutype_macros/src/integer/gen/traits/mod.rs
+++ b/nutype_macros/src/integer/gen/traits/mod.rs
@@ -197,7 +197,7 @@ fn gen_implemented_traits<T: ToTokens>(
             IntegerIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
             IntegerIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type)),
             IntegerIrregularTrait::TryFrom => {
-                Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name.as_ref()))
             }
             IntegerIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             IntegerIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),

--- a/nutype_macros/src/integer/gen/traits/mod.rs
+++ b/nutype_macros/src/integer/gen/traits/mod.rs
@@ -190,7 +190,7 @@ fn gen_implemented_traits<T: ToTokens>(
         .iter()
         .map(|t| match t {
             IntegerIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, inner_type)),
-            IntegerIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, inner_type)),
+            IntegerIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, inner_type)),
             IntegerIrregularTrait::FromStr => {
                 Ok(gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref()))
             }

--- a/nutype_macros/src/integer/gen/traits/mod.rs
+++ b/nutype_macros/src/integer/gen/traits/mod.rs
@@ -24,6 +24,7 @@ type IntegerGeneratableTrait = GeneratableTrait<IntegerTransparentTrait, Integer
 
 pub fn gen_traits<T: ToTokens>(
     type_name: &TypeName,
+    generics: &Generics,
     inner_type: &IntegerInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
     traits: HashSet<IntegerDeriveTrait>,
@@ -43,6 +44,7 @@ pub fn gen_traits<T: ToTokens>(
 
     let implement_traits = gen_implemented_traits(
         type_name,
+        generics,
         inner_type,
         maybe_error_type_name,
         irregular_traits,
@@ -177,6 +179,7 @@ impl ToTokens for IntegerTransparentTrait {
 
 fn gen_implemented_traits<T: ToTokens>(
     type_name: &TypeName,
+    generics: &Generics,
     inner_type: &IntegerInnerType,
     maybe_error_type_name: Option<ErrorTypeName>,
     impl_traits: Vec<IntegerIrregularTrait>,
@@ -191,13 +194,13 @@ fn gen_implemented_traits<T: ToTokens>(
             IntegerIrregularTrait::FromStr => {
                 Ok(gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
-            IntegerIrregularTrait::From => Ok(gen_impl_trait_from(type_name, inner_type)),
-            IntegerIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, &Generics::default(), inner_type)),
+            IntegerIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
+            IntegerIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type)),
             IntegerIrregularTrait::TryFrom => {
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
             IntegerIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
-            IntegerIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, &Generics::default())),
+            IntegerIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             IntegerIrregularTrait::Default => {
                 match maybe_default_value {
                     Some(ref default_value) => {

--- a/nutype_macros/src/integer/gen/traits/mod.rs
+++ b/nutype_macros/src/integer/gen/traits/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::Generics;
 
 use crate::{
     common::{
@@ -196,7 +197,7 @@ fn gen_implemented_traits<T: ToTokens>(
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
             IntegerIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
-            IntegerIrregularTrait::Display => Ok(gen_impl_trait_display(type_name)),
+            IntegerIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, &Generics::default())),
             IntegerIrregularTrait::Default => {
                 match maybe_default_value {
                     Some(ref default_value) => {

--- a/nutype_macros/src/integer/gen/traits/mod.rs
+++ b/nutype_macros/src/integer/gen/traits/mod.rs
@@ -192,7 +192,7 @@ fn gen_implemented_traits<T: ToTokens>(
                 Ok(gen_impl_trait_from_str(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
             IntegerIrregularTrait::From => Ok(gen_impl_trait_from(type_name, inner_type)),
-            IntegerIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, inner_type)),
+            IntegerIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, &Generics::default(), inner_type)),
             IntegerIrregularTrait::TryFrom => {
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }

--- a/nutype_macros/src/integer/gen/traits/mod.rs
+++ b/nutype_macros/src/integer/gen/traits/mod.rs
@@ -199,7 +199,7 @@ fn gen_implemented_traits<T: ToTokens>(
             IntegerIrregularTrait::TryFrom => {
                 Ok(gen_impl_trait_try_from(type_name, inner_type, maybe_error_type_name.as_ref()))
             }
-            IntegerIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, inner_type)),
+            IntegerIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             IntegerIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
             IntegerIrregularTrait::Default => {
                 match maybe_default_value {

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -176,7 +176,7 @@ impl GenerateNewtype for StringNewtype {
 
     fn gen_traits(
         type_name: &TypeName,
-        _generics: &Generics,
+        generics: &Generics,
         _inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,
@@ -185,6 +185,7 @@ impl GenerateNewtype for StringNewtype {
     ) -> Result<GeneratedTraits, syn::Error> {
         gen_traits(
             type_name,
+            generics,
             maybe_error_type_name,
             traits,
             maybe_default_value,

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -71,7 +71,7 @@ impl GenerateNewtype for StringNewtype {
             .collect();
 
         quote!(
-            fn sanitize(value: String) -> String {
+            fn __sanitize__(value: String) -> String {
                 #transformations
                 value
             }
@@ -158,7 +158,7 @@ impl GenerateNewtype for StringNewtype {
         };
 
         quote!(
-            fn validate(val: &str) -> ::core::result::Result<(), #error_name> {
+            fn __validate__(val: &str) -> ::core::result::Result<(), #error_name> {
                 #chars_count_if_required
                 #validations
                 Ok(())

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::Generics;
 
 use crate::{
     common::{
@@ -175,6 +176,7 @@ impl GenerateNewtype for StringNewtype {
 
     fn gen_traits(
         type_name: &TypeName,
+        _generics: &Generics,
         _inner_type: &Self::InnerType,
         maybe_error_type_name: Option<ErrorTypeName>,
         traits: HashSet<Self::TypedTrait>,

--- a/nutype_macros/src/string/gen/traits/mod.rs
+++ b/nutype_macros/src/string/gen/traits/mod.rs
@@ -278,8 +278,9 @@ fn gen_impl_try_from(
 }
 
 fn gen_impl_borrow_str_and_string(type_name: &TypeName) -> TokenStream {
-    let impl_borrow_string = gen_impl_trait_borrow(type_name, quote!(String));
-    let impl_borrow_str = gen_impl_trait_borrow(type_name, quote!(str));
+    let generics = Generics::default();
+    let impl_borrow_string = gen_impl_trait_borrow(type_name, &generics, quote!(String));
+    let impl_borrow_str = gen_impl_trait_borrow(type_name, &generics, quote!(str));
 
     quote! {
         #impl_borrow_string

--- a/nutype_macros/src/string/gen/traits/mod.rs
+++ b/nutype_macros/src/string/gen/traits/mod.rs
@@ -267,9 +267,11 @@ fn gen_impl_try_from(
     type_name: &TypeName,
     maybe_error_type_name: Option<&ErrorTypeName>,
 ) -> TokenStream {
+    let generics = Generics::default();
     let impl_try_from_string =
-        gen_impl_trait_try_from(type_name, quote!(String), maybe_error_type_name);
-    let impl_try_from_str = gen_impl_trait_try_from(type_name, quote!(&str), maybe_error_type_name);
+        gen_impl_trait_try_from(type_name, &generics, quote!(String), maybe_error_type_name);
+    let impl_try_from_str =
+        gen_impl_trait_try_from(type_name, &generics, quote!(&str), maybe_error_type_name);
 
     quote! {
         #impl_try_from_string

--- a/nutype_macros/src/string/gen/traits/mod.rs
+++ b/nutype_macros/src/string/gen/traits/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
+use syn::Generics;
 
 use crate::{
     common::{
@@ -190,7 +191,7 @@ fn gen_implemented_traits(
                 Ok(gen_impl_try_from(type_name, maybe_error_type_name.as_ref()))
             }
             StringIrregularTrait::Borrow => Ok(gen_impl_borrow_str_and_string(type_name)),
-            StringIrregularTrait::Display => Ok(gen_impl_trait_display(type_name)),
+            StringIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, &Generics::default())),
             StringIrregularTrait::Default => match maybe_default_value {
                 Some(ref default_value) => {
                     let has_validation = maybe_error_type_name.is_some();

--- a/nutype_macros/src/string/gen/traits/mod.rs
+++ b/nutype_macros/src/string/gen/traits/mod.rs
@@ -138,6 +138,7 @@ impl ToTokens for StringTransparentTrait {
 
 pub fn gen_traits(
     type_name: &TypeName,
+    generics: &Generics,
     maybe_error_type_name: Option<ErrorTypeName>,
     traits: HashSet<StringDeriveTrait>,
     maybe_default_value: Option<syn::Expr>,
@@ -156,6 +157,7 @@ pub fn gen_traits(
 
     let implement_traits = gen_implemented_traits(
         type_name,
+        generics,
         maybe_error_type_name,
         maybe_default_value,
         irregular_traits,
@@ -170,6 +172,7 @@ pub fn gen_traits(
 
 fn gen_implemented_traits(
     type_name: &TypeName,
+    generics: &Generics,
     maybe_error_type_name: Option<ErrorTypeName>,
     maybe_default_value: Option<syn::Expr>,
     impl_traits: Vec<StringIrregularTrait>,
@@ -181,7 +184,7 @@ fn gen_implemented_traits(
         .iter()
         .map(|t| match t {
             StringIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, quote!(str))),
-            StringIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, quote!(String))),
+            StringIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, quote!(String))),
             StringIrregularTrait::FromStr => {
                 Ok(gen_impl_from_str(type_name, maybe_error_type_name.as_ref()))
             }

--- a/nutype_macros/src/string/gen/traits/mod.rs
+++ b/nutype_macros/src/string/gen/traits/mod.rs
@@ -250,8 +250,9 @@ fn gen_impl_from_str(
 }
 
 fn gen_impl_from_str_and_string(type_name: &TypeName) -> TokenStream {
-    let impl_from_string = gen_impl_trait_from(type_name, quote!(String));
-    let impl_from_str = gen_impl_trait_from(type_name, quote!(&str));
+    let generics = Generics::default();
+    let impl_from_string = gen_impl_trait_from(type_name, &generics, quote!(String));
+    let impl_from_str = gen_impl_trait_from(type_name, &generics, quote!(&str));
 
     quote! {
         #impl_from_string

--- a/nutype_macros/src/string/gen/traits/mod.rs
+++ b/nutype_macros/src/string/gen/traits/mod.rs
@@ -186,7 +186,7 @@ fn gen_implemented_traits(
                 Ok(gen_impl_from_str(type_name, maybe_error_type_name.as_ref()))
             }
             StringIrregularTrait::From => Ok(gen_impl_from_str_and_string(type_name)),
-            StringIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, inner_type)),
+            StringIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, &Generics::default(), inner_type)),
             StringIrregularTrait::TryFrom => {
                 Ok(gen_impl_try_from(type_name, maybe_error_type_name.as_ref()))
             }

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -488,18 +488,16 @@ mod with_generics {
     fn test_generic_with_lifetime_cow() {
         #[nutype(
             validate(predicate = |s| s.len() >= 3),
-            derive(Debug)
+            derive(Debug, Display)
         )]
         struct Clarabelle<'a>(Cow<'a, str>);
 
         {
             let clarabelle = Clarabelle::new(Cow::Borrowed("Clarabelle")).unwrap();
-            assert_eq!(clarabelle.into_inner(), Cow::Borrowed("Clarabelle"));
-        }
+            assert_eq!(clarabelle.to_string(), "Clarabelle");
 
-        {
-            let err = Clarabelle::new(Cow::Borrowed("Mu")).unwrap_err();
-            assert_eq!(err, ClarabelleError::PredicateViolated);
+            let muu = Clarabelle::new(Cow::Owned("Muu".to_string())).unwrap();
+            assert_eq!(muu.to_string(), "Muu");
         }
     }
 }

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -488,7 +488,7 @@ mod with_generics {
     fn test_generic_with_lifetime_cow() {
         #[nutype(
             validate(predicate = |s| s.len() >= 3),
-            derive(Debug, Display)
+            derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Into)
         )]
         struct Clarabelle<'a>(Cow<'a, str>);
 

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -1,4 +1,5 @@
 use nutype::nutype;
+use std::borrow::Cow;
 use test_suite::test_helpers::traits::*;
 
 // Inner custom type, which is unknown to nutype
@@ -482,4 +483,23 @@ mod with_generics {
     //     assert_eq!(err, NonEmptyVecError::PredicateViolated);
     // }
     // }
+
+    #[test]
+    fn test_generic_with_lifetime_cow() {
+        #[nutype(
+            validate(predicate = |s| s.len() >= 3),
+            derive(Debug)
+        )]
+        struct Clarabelle<'a>(Cow<'a, str>);
+
+        {
+            let clarabelle = Clarabelle::new(Cow::Borrowed("Clarabelle")).unwrap();
+            assert_eq!(clarabelle.into_inner(), Cow::Borrowed("Clarabelle"));
+        }
+
+        {
+            let err = Clarabelle::new(Cow::Borrowed("Mu")).unwrap_err();
+            assert_eq!(err, ClarabelleError::PredicateViolated);
+        }
+    }
 }

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -488,6 +488,7 @@ mod with_generics {
     fn test_generic_with_lifetime_cow() {
         #[nutype(
             validate(predicate = |s| s.len() >= 3),
+            // TODO: derive TryFrom
             derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Into)
         )]
         struct Clarabelle<'a>(Cow<'a, str>);

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -488,8 +488,7 @@ mod with_generics {
     fn test_generic_with_lifetime_cow() {
         #[nutype(
             validate(predicate = |s| s.len() >= 3),
-            // TODO: derive TryFrom
-            derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Into, Deref)
+            derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Into, Deref, Borrow, TryFrom)
         )]
         struct Clarabelle<'a>(Cow<'a, str>);
 

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -489,7 +489,7 @@ mod with_generics {
         #[nutype(
             validate(predicate = |s| s.len() >= 3),
             // TODO: derive TryFrom
-            derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Into)
+            derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Into, Deref)
         )]
         struct Clarabelle<'a>(Cow<'a, str>);
 


### PR DESCRIPTION
This is still work in progress.
It's supposed to address https://github.com/greyblake/nutype/issues/133 and https://github.com/greyblake/nutype/issues/130


### To do
* [x] Find a way to fix clippy warning  `using a reference to Cow is not recommended` in
```rs
#[nutype(
    derive(Debug),
    validate(predicate = |s| s.len() >= 3),
)]
struct Clarabelle<'b>(Cow<'b, str>);
```

* [x] Use internally a very unique lifetime identifier, instead of `'a`. E.g. Ensure that this works:
```rs
#[nutype(
    derive(Debug),
    validate(predicate = |s| s.len() >= 3),
)]
struct Clarabelle<'a>(Cow<'a, str>);
```

* [x] Make sure the example with `Clarabelle` can derive `Display` and other traits
* [ ] Make it possible to set trait boundaries:
```rs
#[nutype(
    sanitize(with = |v| { v.sort(); v }),
    derive(Debug)
)]
struct SortedVec<T: Ord>(Vec<T>)
```
NOTE: this will be handled in a separate story: https://github.com/greyblake/nutype/issues/142