### PR TITLE
Use absolute path for Result in macro-generated code

### DIFF
--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -169,7 +169,7 @@ pub fn gen_impl_trait_try_from(
                     type Error = #error_type_name;
 
                     #[inline]
-                    fn try_from(raw_value: #inner_type) -> Result<#type_name #generics, Self::Error> {
+                    fn try_from(raw_value: #inner_type) -> ::core::result::Result<#type_name #generics, Self::Error> {
                         Self::new(raw_value)
                     }
                 }
@@ -183,7 +183,7 @@ pub fn gen_impl_trait_try_from(
                     type Error = ::core::convert::Infallible;
 
                     #[inline]
-                    fn try_from(raw_value: #inner_type) -> Result<#type_name #generics, Self::Error> {
+                    fn try_from(raw_value: #inner_type) -> ::core::result::Result<#type_name #generics, Self::Error> {
                         Ok(Self::new(raw_value))
                     }
                 }
@@ -286,7 +286,7 @@ pub fn gen_impl_trait_serde_deserialize(
 
     quote! {
         impl #all_generics ::serde::Deserialize<'de> for #type_name #type_generics {
-            fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> ::core::result::Result<Self, D::Error> {
                 struct __Visitor #all_generics {
                     marker: ::std::marker::PhantomData<#type_name #type_generics>,
                     lifetime: ::std::marker::PhantomData<&'de ()>,
@@ -299,7 +299,7 @@ pub fn gen_impl_trait_serde_deserialize(
                         write!(formatter, #expecting_str)
                     }
 
-                    fn visit_newtype_struct<DE>(self, deserializer: DE) -> Result<Self::Value, DE::Error>
+                    fn visit_newtype_struct<DE>(self, deserializer: DE) -> ::core::result::Result<Self::Value, DE::Error>
                     where
                         DE: ::serde::Deserializer<'de>
                     {

--- a/nutype_macros/src/float/models.rs
+++ b/nutype_macros/src/float/models.rs
@@ -101,7 +101,7 @@ macro_rules! define_float_inner_type {
         }
 
         impl ::core::fmt::Display for FloatInnerType {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 match self {
                     $(
                         Self::$variant => stringify!($tp).fmt(f),

--- a/nutype_macros/src/integer/models.rs
+++ b/nutype_macros/src/integer/models.rs
@@ -101,7 +101,7 @@ macro_rules! define_integer_inner_type {
         }
 
         impl ::core::fmt::Display for IntegerInnerType {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> Result<(), ::core::fmt::Error> {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 match self {
                     $(
                         Self::$variant => stringify!($tp).fmt(f),


### PR DESCRIPTION
Hi! Thanks for this useful software.

## Description

This pull request addresses a compilation error that occurs when using the crate with a custom Result type alias and deriving certain traits such as `Deserialize` from `serde`. For example:

```rust
#[nutype(derive(Deserialize))]
struct Name(String);

struct MyError;
pub type Result<T> = std::result::Result<T, MyError>;
```

The error message was:
```
type alias takes 1 generic argument but 2 generic arguments were supplied
expected 1 generic argument
```

## Changes

- Updated macros to use the absolute path (e.g. `::core::result::Result`) for Result.

Thanks!