### PR TITLE
Refactor: add error_type_name to Guard::WithValidation and downstream it instead of generate name in place

### DIFF
--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,24 +1,48 @@
+/*
 use nutype::nutype;
 
+// Validation function
+fn validate_name(name: &str) -> Result<(), NameError> {
+    if name.len() < 3 {
+        Err(NameError::TooShort)
+    } else if name.len() > 20 {
+        Err(NameError::TooLong)
+    } else {
+        Ok(())
+    }
+}
+
+// Name validation error
+#[derive(Debug)]
+enum NameError {
+    TooShort,
+    TooLong,
+}
+
+// Variant 1: with and error
 #[nutype(
-    sanitize(with = |mut v| { v.sort(); v }),
-    validate(predicate = |vec| !vec.is_empty()),
+    sanitize(trim),
+    validate(with = validate_name, error = NameError),
     derive(Debug, AsRef, PartialEq, Deref),
 )]
-struct SortedNotEmptyVec<T: Ord>(Vec<T>);
+struct Name(String);
 
-fn main() {
-    // Empty list is not allowed
-    assert_eq!(
-        SortedNotEmptyVec::<&str>::try_new(vec![]),
-        Err(SortedNotEmptyVecError::PredicateViolated)
-    );
+// Variant 2: `custom` and `custom_error`
+#[nutype(
+    sanitize(trim),
+    validate(custom = validate_name, custom_error = NameError),
+    derive(Debug, AsRef, PartialEq, Deref),
+)]
+struct Name(String);
 
-    let wise_friends = SortedNotEmptyVec::try_new(vec!["Seneca", "Zeno", "Plato"]).unwrap();
-    assert_eq!(wise_friends.as_ref(), &["Plato", "Seneca", "Zeno"]);
-    assert_eq!(wise_friends.len(), 3);
+// Variant 3:
+#[nutype(
+    sanitize(trim),
+    validate(with = validate_name),
+    derive(Debug, AsRef, PartialEq, Deref),
+    error = NameError,
+)]
+struct Name(String);
+*/
 
-    let numbers = SortedNotEmptyVec::try_new(vec![4, 2, 7, 1]).unwrap();
-    assert_eq!(numbers.as_ref(), &[1, 2, 4, 7]);
-    assert_eq!(numbers.len(), 4);
-}
+fn main() {}

--- a/nutype_macros/src/any/gen/error.rs
+++ b/nutype_macros/src/any/gen/error.rs
@@ -4,16 +4,19 @@ use quote::quote;
 use crate::{
     any::models::AnyValidator,
     common::{
-        gen::error::{gen_error_type_name, gen_impl_error_trait},
+        gen::error::gen_impl_error_trait,
         models::{ErrorTypeName, TypeName},
     },
 };
 
-pub fn gen_validation_error_type(type_name: &TypeName, validators: &[AnyValidator]) -> TokenStream {
-    let error_type_name = gen_error_type_name(type_name);
-    let definition = gen_definition(&error_type_name, validators);
-    let impl_display_trait = gen_impl_display_trait(type_name, &error_type_name, validators);
-    let impl_error_trait = gen_impl_error_trait(&error_type_name);
+pub fn gen_validation_error_type(
+    type_name: &TypeName,
+    error_type_name: &ErrorTypeName,
+    validators: &[AnyValidator],
+) -> TokenStream {
+    let definition = gen_definition(error_type_name, validators);
+    let impl_display_trait = gen_impl_display_trait(type_name, error_type_name, validators);
+    let impl_error_trait = gen_impl_error_trait(error_type_name);
 
     quote! {
         #[derive(Debug, Clone, PartialEq, Eq)]

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -15,7 +15,7 @@ use crate::{
             gen_impl_trait_serde_serialize, gen_impl_trait_try_from, split_into_generatable_traits,
             GeneratableTrait, GeneratableTraits, GeneratedTraits,
         },
-        models::{ErrorTypeName, TypeName},
+        models::TypeName,
     },
 };
 
@@ -109,7 +109,6 @@ pub fn gen_traits(
     type_name: &TypeName,
     generics: &syn::Generics,
     inner_type: &AnyInnerType,
-    maybe_error_type_name: Option<ErrorTypeName>,
     traits: HashSet<AnyDeriveTrait>,
     maybe_default_value: Option<syn::Expr>,
     guard: &AnyGuard,
@@ -129,7 +128,6 @@ pub fn gen_traits(
         type_name,
         generics,
         inner_type,
-        maybe_error_type_name,
         irregular_traits,
         maybe_default_value,
         guard,
@@ -145,11 +143,11 @@ fn gen_implemented_traits(
     type_name: &TypeName,
     generics: &syn::Generics,
     inner_type: &AnyInnerType,
-    maybe_error_type_name: Option<ErrorTypeName>,
     impl_traits: Vec<AnyIrregularTrait>,
     maybe_default_value: Option<syn::Expr>,
     guard: &AnyGuard,
 ) -> Result<TokenStream, syn::Error> {
+    let maybe_error_type_name = guard.maybe_error_type_name();
     impl_traits
         .iter()
         .map(|t| match t {
@@ -160,10 +158,10 @@ fn gen_implemented_traits(
             AnyIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, inner_type)),
             AnyIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             AnyIrregularTrait::FromStr => Ok(
-                gen_impl_trait_from_str(type_name, generics, inner_type, maybe_error_type_name.as_ref())
+                gen_impl_trait_from_str(type_name, generics, inner_type, maybe_error_type_name)
             ),
             AnyIrregularTrait::TryFrom => Ok(
-                gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name.as_ref())
+                gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name)
             ),
             AnyIrregularTrait::Default => match maybe_default_value {
                 Some(ref default_value) => {
@@ -180,7 +178,7 @@ fn gen_implemented_traits(
                 gen_impl_trait_serde_serialize(type_name, generics)
             ),
             AnyIrregularTrait::SerdeDeserialize => Ok(
-                gen_impl_trait_serde_deserialize(type_name, generics, inner_type, maybe_error_type_name.as_ref())
+                gen_impl_trait_serde_deserialize(type_name, generics, inner_type, maybe_error_type_name)
             ),
             AnyIrregularTrait::ArbitraryArbitrary => arbitrary::gen_impl_trait_arbitrary(type_name, generics, inner_type, guard),
         })

--- a/nutype_macros/src/any/mod.rs
+++ b/nutype_macros/src/any/mod.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 
 use self::models::{AnyDeriveTrait, AnyGuard, AnyInnerType, AnySanitizer, AnyValidator};
 use crate::common::gen::GenerateNewtype;
+use crate::common::models::TypeName;
 use crate::{
     any::validate::validate_any_derive_traits,
     common::models::{Attributes, GenerateParams, Newtype, SpannedDeriveTrait},
@@ -23,8 +24,9 @@ impl Newtype for AnyNewtype {
 
     fn parse_attributes(
         attrs: TokenStream,
+        type_name: &TypeName,
     ) -> Result<Attributes<AnyGuard, SpannedDeriveTrait>, syn::Error> {
-        parse::parse_attributes(attrs)
+        parse::parse_attributes(attrs, type_name)
     }
 
     fn validate(

--- a/nutype_macros/src/any/parse.rs
+++ b/nutype_macros/src/any/parse.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    models::{Attributes, CustomFunction, SpannedDeriveTrait},
+    models::{Attributes, CustomFunction, SpannedDeriveTrait, TypeName},
     parse::{parse_sanitizer_kind, parse_validator_kind, ParseableAttributes},
 };
 use proc_macro2::TokenStream;
@@ -18,6 +18,7 @@ use super::{
 
 pub fn parse_attributes(
     input: TokenStream,
+    type_name: &TypeName,
 ) -> Result<Attributes<AnyGuard, SpannedDeriveTrait>, syn::Error> {
     let attrs: ParseableAttributes<SpannedAnySanitizer, SpannedAnyValidator> = syn::parse2(input)?;
 
@@ -27,12 +28,14 @@ pub fn parse_attributes(
         new_unchecked,
         default,
         derive_traits,
+        error_type_name,
     } = attrs;
     let raw_guard = AnyRawGuard {
         sanitizers,
         validators,
+        error_type_name,
     };
-    let guard = validate_any_guard(raw_guard)?;
+    let guard = validate_any_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
         guard,

--- a/nutype_macros/src/any/validate.rs
+++ b/nutype_macros/src/any/validate.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use proc_macro2::Span;
 
 use crate::common::{
-    models::{DeriveTrait, SpannedDeriveTrait},
-    validate::{validate_duplicates, validate_traits_from_xor_try_from},
+    models::{DeriveTrait, SpannedDeriveTrait, TypeName},
+    validate::{validate_duplicates, validate_guard, validate_traits_from_xor_try_from},
 };
 
 use super::models::{
@@ -12,25 +12,20 @@ use super::models::{
     SpannedAnyValidator,
 };
 
-pub fn validate_any_guard(raw_guard: AnyRawGuard) -> Result<AnyGuard, syn::Error> {
-    let AnyRawGuard {
-        sanitizers,
-        validators,
-    } = raw_guard;
-
-    let validators = validate_validators(validators)?;
-    let sanitizers = validate_sanitizers(sanitizers)?;
-
-    if validators.is_empty() {
-        Ok(AnyGuard::WithoutValidation { sanitizers })
-    } else {
-        Ok(AnyGuard::WithValidation {
-            sanitizers,
-            validators,
-        })
-    }
+pub fn validate_any_guard(
+    raw_guard: AnyRawGuard,
+    type_name: &TypeName,
+) -> Result<AnyGuard, syn::Error> {
+    validate_guard(
+        raw_guard,
+        type_name,
+        validate_validators,
+        validate_sanitizers,
+    )
 }
 
+// > Quis custodiet ipsos custodes? :D
+// (Who will guard the guards themselves?)
 fn validate_validators(
     validators: Vec<SpannedAnyValidator>,
 ) -> Result<Vec<AnyValidator>, syn::Error> {

--- a/nutype_macros/src/common/gen/error.rs
+++ b/nutype_macros/src/common/gen/error.rs
@@ -4,6 +4,8 @@ use quote::{format_ident, quote};
 
 use crate::common::models::{ErrorTypeName, TypeName};
 
+/// Generate a default error type name if the error name is not specified explicitly by
+/// the user in the attributes.
 pub fn gen_error_type_name(type_name: &TypeName) -> ErrorTypeName {
     let ident = format_ident!("{type_name}Error");
     ErrorTypeName::new(ident)

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -122,6 +122,10 @@ macro_rules! define_ident_type {
             pub fn new(name: proc_macro2::Ident) -> Self {
                 Self(name)
             }
+
+            pub fn span(&self) -> Span {
+                self.0.span()
+            }
         }
 
         impl core::fmt::Display for $tp_name {
@@ -205,7 +209,19 @@ pub enum Guard<Sanitizer, Validator> {
     WithValidation {
         sanitizers: Vec<Sanitizer>,
         validators: Vec<Validator>,
+        error_type_name: ErrorTypeName,
     },
+}
+
+impl<Sanitizer, Validator> Guard<Sanitizer, Validator> {
+    pub fn maybe_error_type_name(&self) -> Option<&ErrorTypeName> {
+        match self {
+            Self::WithoutValidation { .. } => None,
+            Self::WithValidation {
+                error_type_name, ..
+            } => Some(error_type_name),
+        }
+    }
 }
 
 /// Parsed attributes (`sanitize`, `validate`, `new_unchecked`).
@@ -284,6 +300,7 @@ impl<Sanitizer, Validator> Guard<Sanitizer, Validator> {
 pub struct RawGuard<Sanitizer, Validator> {
     pub sanitizers: Vec<Sanitizer>,
     pub validators: Vec<Validator>,
+    pub error_type_name: Option<ErrorTypeName>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -362,6 +379,7 @@ pub trait Newtype {
     #[allow(clippy::type_complexity)]
     fn parse_attributes(
         attrs: TokenStream,
+        type_name: &TypeName,
     ) -> Result<Attributes<Guard<Self::Sanitizer, Self::Validator>, SpannedDeriveTrait>, syn::Error>;
 
     fn validate(
@@ -394,7 +412,7 @@ pub trait Newtype {
             new_unchecked,
             default: maybe_default_value,
             derive_traits,
-        } = Self::parse_attributes(attrs)?;
+        } = Self::parse_attributes(attrs, &type_name)?;
         let traits = Self::validate(&guard, derive_traits)?;
         let generated_output = Self::generate(GenerateParams {
             doc_attrs,

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -122,10 +122,6 @@ macro_rules! define_ident_type {
             pub fn new(name: proc_macro2::Ident) -> Self {
                 Self(name)
             }
-
-            pub fn span(&self) -> Span {
-                self.0.span()
-            }
         }
 
         impl core::fmt::Display for $tp_name {
@@ -149,6 +145,12 @@ define_ident_type!(TypeName);
 // Represents a type for a validation error.
 // For example, if `TypeName` is `Email`, then `ErrorTypeName` would usually be `EmailError`.
 define_ident_type!(ErrorTypeName);
+
+impl ErrorTypeName {
+    pub fn span(&self) -> Span {
+        self.0.span()
+    }
+}
 
 // A type that represents an error name which is returned by `FromStr` traits.
 // For example, if `TypeName` is `Amount`, then this would be `AmountParseError`.

--- a/nutype_macros/src/common/parse/mod.rs
+++ b/nutype_macros/src/common/parse/mod.rs
@@ -15,7 +15,9 @@ use syn::{
 
 use crate::common::models::SpannedDeriveTrait;
 
-use super::models::{CustomFunction, NewUnchecked, TypedCustomFunction, ValueOrExpr};
+use super::models::{
+    CustomFunction, ErrorTypeName, NewUnchecked, TypedCustomFunction, ValueOrExpr,
+};
 
 pub fn is_doc_attribute(attribute: &syn::Attribute) -> bool {
     match attribute.path().segments.first() {
@@ -59,11 +61,14 @@ pub struct ParseableAttributes<Sanitizer, Validator> {
     /// Parsed from `new_unchecked` attribute
     pub new_unchecked: NewUnchecked,
 
-    /// Parsed from `new_unchecked` attribute
+    /// Parsed from `default = ` attribute
     pub default: Option<Expr>,
 
     /// Parsed from `derive(...)` attribute
     pub derive_traits: Vec<SpannedDeriveTrait>,
+
+    /// TODO: not implemented yet
+    pub error_type_name: Option<ErrorTypeName>,
 }
 
 // By some reason Default cannot be derived.
@@ -75,6 +80,7 @@ impl<Sanitizer, Validator> Default for ParseableAttributes<Sanitizer, Validator>
             new_unchecked: NewUnchecked::Off,
             default: None,
             derive_traits: vec![],
+            error_type_name: None,
         }
     }
 }

--- a/nutype_macros/src/float/gen/error.rs
+++ b/nutype_macros/src/float/gen/error.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
 use crate::common::{
-    gen::error::{gen_error_type_name, gen_impl_error_trait},
+    gen::error::gen_impl_error_trait,
     models::{ErrorTypeName, TypeName},
 };
 
@@ -10,12 +10,12 @@ use super::super::models::FloatValidator;
 
 pub fn gen_validation_error_type<T: ToTokens>(
     type_name: &TypeName,
+    error_type_name: &ErrorTypeName,
     validators: &[FloatValidator<T>],
 ) -> TokenStream {
-    let error_type_name = gen_error_type_name(type_name);
-    let definition = gen_definition(&error_type_name, validators);
-    let impl_display_trait = gen_impl_display_trait(type_name, &error_type_name, validators);
-    let impl_error_trait = gen_impl_error_trait(&error_type_name);
+    let definition = gen_definition(error_type_name, validators);
+    let impl_display_trait = gen_impl_display_trait(type_name, error_type_name, validators);
+    let impl_error_trait = gen_impl_error_trait(error_type_name);
 
     quote! {
         #[derive(Debug, Clone, PartialEq, Eq)]

--- a/nutype_macros/src/float/gen/traits/arbitrary.rs
+++ b/nutype_macros/src/float/gen/traits/arbitrary.rs
@@ -66,6 +66,7 @@ fn gen_generate_valid_inner_value<T: ToTokens>(
         FloatGuard::WithValidation {
             sanitizers,
             validators,
+            error_type_name: _,
         } => {
             // When there is validation, then we need to generate a valid value.
             gen_generate_valid_inner_value_with_validators(inner_type, sanitizers, validators)

--- a/nutype_macros/src/float/gen/traits/mod.rs
+++ b/nutype_macros/src/float/gen/traits/mod.rs
@@ -14,7 +14,7 @@ use crate::{
             gen_impl_trait_serde_serialize, gen_impl_trait_try_from, split_into_generatable_traits,
             GeneratableTrait, GeneratableTraits, GeneratedTraits,
         },
-        models::{ErrorTypeName, TypeName},
+        models::TypeName,
     },
     float::models::{FloatDeriveTrait, FloatGuard, FloatInnerType},
 };
@@ -125,7 +125,6 @@ pub fn gen_traits<T: ToTokens>(
     type_name: &TypeName,
     generics: &Generics,
     inner_type: &FloatInnerType,
-    maybe_error_type_name: Option<ErrorTypeName>,
     maybe_default_value: Option<syn::Expr>,
     traits: HashSet<FloatDeriveTrait>,
     guard: &FloatGuard<T>,
@@ -145,7 +144,6 @@ pub fn gen_traits<T: ToTokens>(
         type_name,
         generics,
         inner_type,
-        maybe_error_type_name,
         maybe_default_value,
         irregular_traits,
         guard,
@@ -161,23 +159,23 @@ fn gen_implemented_traits<T: ToTokens>(
     type_name: &TypeName,
     generics: &Generics,
     inner_type: &FloatInnerType,
-    maybe_error_type_name: Option<ErrorTypeName>,
     maybe_default_value: Option<syn::Expr>,
     impl_traits: Vec<FloatIrregularTrait>,
     guard: &FloatGuard<T>,
 ) -> Result<TokenStream, syn::Error> {
+    let maybe_error_type_name = guard.maybe_error_type_name();
     impl_traits
         .iter()
         .map(|t| match t {
             FloatIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, generics, inner_type)),
             FloatIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, inner_type)),
             FloatIrregularTrait::FromStr => {
-                Ok(gen_impl_trait_from_str(type_name, generics, inner_type, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_trait_from_str(type_name, generics, inner_type, maybe_error_type_name))
             }
             FloatIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
             FloatIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type)),
             FloatIrregularTrait::TryFrom => {
-                Ok(gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name))
             }
             FloatIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             FloatIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
@@ -197,7 +195,7 @@ fn gen_implemented_traits<T: ToTokens>(
                 type_name,
                 generics,
                 inner_type,
-                maybe_error_type_name.as_ref(),
+                maybe_error_type_name,
             )),
             FloatIrregularTrait::Eq => Ok(gen_impl_trait_eq(type_name)),
             FloatIrregularTrait::Ord => Ok(gen_impl_trait_ord(type_name)),

--- a/nutype_macros/src/float/mod.rs
+++ b/nutype_macros/src/float/mod.rs
@@ -10,7 +10,7 @@ use quote::ToTokens;
 
 use crate::common::{
     gen::GenerateNewtype,
-    models::{Attributes, GenerateParams, Guard, Newtype, SpannedDeriveTrait},
+    models::{Attributes, GenerateParams, Guard, Newtype, SpannedDeriveTrait, TypeName},
 };
 
 use self::{
@@ -39,8 +39,9 @@ where
 
     fn parse_attributes(
         attrs: TokenStream,
+        type_name: &TypeName,
     ) -> Result<Attributes<FloatGuard<T>, SpannedDeriveTrait>, syn::Error> {
-        parse::parse_attributes::<T>(attrs)
+        parse::parse_attributes::<T>(attrs, type_name)
     }
 
     fn validate(

--- a/nutype_macros/src/float/parse.rs
+++ b/nutype_macros/src/float/parse.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::common::{
-    models::{Attributes, SpannedDeriveTrait},
+    models::{Attributes, SpannedDeriveTrait, TypeName},
     parse::{
         parse_number_or_expr, parse_sanitizer_kind, parse_typed_custom_function,
         parse_validator_kind, ParseableAttributes,
@@ -21,11 +21,12 @@ use super::{
         FloatGuard, FloatRawGuard, FloatSanitizer, FloatSanitizerKind, FloatValidator,
         FloatValidatorKind, SpannedFloatSanitizer, SpannedFloatValidator,
     },
-    validate::validate_number_meta,
+    validate::validate_float_guard,
 };
 
 pub fn parse_attributes<T>(
     input: TokenStream,
+    type_name: &TypeName,
 ) -> Result<Attributes<FloatGuard<T>, SpannedDeriveTrait>, syn::Error>
 where
     T: FromStr + PartialOrd + Clone,
@@ -40,12 +41,14 @@ where
         new_unchecked,
         default,
         derive_traits,
+        error_type_name,
     } = attrs;
     let raw_guard = FloatRawGuard {
         sanitizers,
         validators,
+        error_type_name,
     };
-    let guard = validate_number_meta(raw_guard)?;
+    let guard = validate_float_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
         guard,

--- a/nutype_macros/src/integer/gen/error.rs
+++ b/nutype_macros/src/integer/gen/error.rs
@@ -3,18 +3,18 @@ use quote::{quote, ToTokens};
 
 use super::super::models::IntegerValidator;
 use crate::common::{
-    gen::error::{gen_error_type_name, gen_impl_error_trait},
+    gen::error::gen_impl_error_trait,
     models::{ErrorTypeName, TypeName},
 };
 
 pub fn gen_validation_error_type<T: ToTokens>(
     type_name: &TypeName,
+    error_type_name: &ErrorTypeName,
     validators: &[IntegerValidator<T>],
 ) -> TokenStream {
-    let error_type_name = gen_error_type_name(type_name);
-    let definition = gen_definition(&error_type_name, validators);
-    let impl_display_trait = gen_impl_display_trait(type_name, &error_type_name, validators);
-    let impl_error_trait = gen_impl_error_trait(&error_type_name);
+    let definition = gen_definition(error_type_name, validators);
+    let impl_display_trait = gen_impl_display_trait(type_name, error_type_name, validators);
+    let impl_error_trait = gen_impl_error_trait(error_type_name);
 
     quote! {
         #[derive(Debug, Clone, PartialEq, Eq)]

--- a/nutype_macros/src/integer/gen/traits/arbitrary.rs
+++ b/nutype_macros/src/integer/gen/traits/arbitrary.rs
@@ -67,6 +67,7 @@ fn guard_to_boundary<T: ToTokens>(
         IntegerGuard::WithValidation {
             sanitizers: _,
             validators,
+            error_type_name: _,
         } => {
             // Apply the validators to the boundaries.
             // Since the validators were already validated, it's guaranteed that they're not

--- a/nutype_macros/src/integer/gen/traits/mod.rs
+++ b/nutype_macros/src/integer/gen/traits/mod.rs
@@ -15,7 +15,7 @@ use crate::{
             gen_impl_trait_serde_serialize, gen_impl_trait_try_from, split_into_generatable_traits,
             GeneratableTrait, GeneratableTraits, GeneratedTraits,
         },
-        models::{ErrorTypeName, TypeName},
+        models::TypeName,
     },
     integer::models::{IntegerDeriveTrait, IntegerGuard, IntegerInnerType},
 };
@@ -26,7 +26,6 @@ pub fn gen_traits<T: ToTokens>(
     type_name: &TypeName,
     generics: &Generics,
     inner_type: &IntegerInnerType,
-    maybe_error_type_name: Option<ErrorTypeName>,
     traits: HashSet<IntegerDeriveTrait>,
     maybe_default_value: Option<syn::Expr>,
     guard: &IntegerGuard<T>,
@@ -46,7 +45,6 @@ pub fn gen_traits<T: ToTokens>(
         type_name,
         generics,
         inner_type,
-        maybe_error_type_name,
         irregular_traits,
         maybe_default_value,
         guard,
@@ -181,23 +179,23 @@ fn gen_implemented_traits<T: ToTokens>(
     type_name: &TypeName,
     generics: &Generics,
     inner_type: &IntegerInnerType,
-    maybe_error_type_name: Option<ErrorTypeName>,
     impl_traits: Vec<IntegerIrregularTrait>,
     maybe_default_value: Option<syn::Expr>,
     guard: &IntegerGuard<T>,
 ) -> Result<TokenStream, syn::Error> {
+    let maybe_error_type_name = guard.maybe_error_type_name();
     impl_traits
         .iter()
         .map(|t| match t {
             IntegerIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, generics, inner_type)),
             IntegerIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, inner_type)),
             IntegerIrregularTrait::FromStr => {
-                Ok(gen_impl_trait_from_str(type_name, generics, inner_type, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_trait_from_str(type_name, generics, inner_type, maybe_error_type_name))
             }
             IntegerIrregularTrait::From => Ok(gen_impl_trait_from(type_name, generics, inner_type)),
             IntegerIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, generics, inner_type)),
             IntegerIrregularTrait::TryFrom => {
-                Ok(gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_trait_try_from(type_name, generics, inner_type, maybe_error_type_name))
             }
             IntegerIrregularTrait::Borrow => Ok(gen_impl_trait_borrow(type_name, generics, inner_type)),
             IntegerIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, generics)),
@@ -219,7 +217,7 @@ fn gen_implemented_traits<T: ToTokens>(
                 type_name,
                 generics,
                 inner_type,
-                maybe_error_type_name.as_ref(),
+                maybe_error_type_name,
             )),
             IntegerIrregularTrait::ArbitraryArbitrary => {
                 arbitrary::gen_impl_trait_arbitrary(type_name, inner_type, guard)

--- a/nutype_macros/src/integer/mod.rs
+++ b/nutype_macros/src/integer/mod.rs
@@ -10,7 +10,7 @@ use quote::ToTokens;
 
 use crate::common::{
     gen::GenerateNewtype,
-    models::{Attributes, GenerateParams, Guard, Newtype, SpannedDeriveTrait},
+    models::{Attributes, GenerateParams, Guard, Newtype, SpannedDeriveTrait, TypeName},
 };
 
 use self::{
@@ -40,8 +40,9 @@ where
 
     fn parse_attributes(
         attrs: TokenStream,
+        type_name: &TypeName,
     ) -> Result<Attributes<IntegerGuard<T>, SpannedDeriveTrait>, syn::Error> {
-        parse::parse_attributes::<T>(attrs)
+        parse::parse_attributes::<T>(attrs, type_name)
     }
 
     fn validate(

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::common::{
-    models::{Attributes, SpannedDeriveTrait},
+    models::{Attributes, SpannedDeriveTrait, TypeName},
     parse::{
         parse_number_or_expr, parse_sanitizer_kind, parse_typed_custom_function,
         parse_validator_kind, ParseableAttributes,
@@ -21,11 +21,12 @@ use super::{
         IntegerGuard, IntegerRawGuard, IntegerSanitizer, IntegerSanitizerKind, IntegerValidator,
         IntegerValidatorKind, SpannedIntegerSanitizer, SpannedIntegerValidator,
     },
-    validate::validate_number_meta,
+    validate::validate_integer_guard,
 };
 
 pub fn parse_attributes<T>(
     input: TokenStream,
+    type_name: &TypeName,
 ) -> Result<Attributes<IntegerGuard<T>, SpannedDeriveTrait>, syn::Error>
 where
     T: FromStr + PartialOrd + Clone,
@@ -40,12 +41,14 @@ where
         new_unchecked,
         default,
         derive_traits,
+        error_type_name,
     } = attrs;
     let raw_guard = IntegerRawGuard {
         sanitizers,
         validators,
+        error_type_name,
     };
-    let guard = validate_number_meta(raw_guard)?;
+    let guard = validate_integer_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
         guard,

--- a/nutype_macros/src/integer/validate.rs
+++ b/nutype_macros/src/integer/validate.rs
@@ -3,8 +3,11 @@ use std::collections::HashSet;
 use proc_macro2::Span;
 
 use crate::common::{
-    models::{DeriveTrait, SpannedDeriveTrait},
-    validate::{validate_duplicates, validate_numeric_bounds, validate_traits_from_xor_try_from},
+    models::{DeriveTrait, SpannedDeriveTrait, TypeName},
+    validate::{
+        validate_duplicates, validate_guard, validate_numeric_bounds,
+        validate_traits_from_xor_try_from,
+    },
 };
 
 use super::models::{
@@ -12,26 +15,19 @@ use super::models::{
     SpannedIntegerSanitizer, SpannedIntegerValidator,
 };
 
-pub fn validate_number_meta<T>(raw_meta: IntegerRawGuard<T>) -> Result<IntegerGuard<T>, syn::Error>
+pub fn validate_integer_guard<T>(
+    raw_guard: IntegerRawGuard<T>,
+    type_name: &TypeName,
+) -> Result<IntegerGuard<T>, syn::Error>
 where
     T: PartialOrd + Clone,
 {
-    let IntegerRawGuard {
-        sanitizers,
-        validators,
-    } = raw_meta;
-
-    let validators = validate_validators(validators)?;
-    let sanitizers = validate_sanitizers(sanitizers)?;
-
-    if validators.is_empty() {
-        Ok(IntegerGuard::WithoutValidation { sanitizers })
-    } else {
-        Ok(IntegerGuard::WithValidation {
-            sanitizers,
-            validators,
-        })
-    }
+    validate_guard(
+        raw_guard,
+        type_name,
+        validate_validators,
+        validate_sanitizers,
+    )
 }
 
 fn validate_validators<T>(

--- a/nutype_macros/src/string/gen/error.rs
+++ b/nutype_macros/src/string/gen/error.rs
@@ -3,7 +3,7 @@ use quote::quote;
 
 use crate::{
     common::{
-        gen::error::{gen_error_type_name, gen_impl_error_trait},
+        gen::error::gen_impl_error_trait,
         models::{ErrorTypeName, TypeName},
     },
     string::models::StringValidator,
@@ -11,12 +11,12 @@ use crate::{
 
 pub fn gen_validation_error_type(
     type_name: &TypeName,
+    error_type_name: &ErrorTypeName,
     validators: &[StringValidator],
 ) -> TokenStream {
-    let error_type_name = gen_error_type_name(type_name);
-    let definition = gen_definition(&error_type_name, validators);
-    let impl_display_trait = gen_impl_display_trait(type_name, &error_type_name, validators);
-    let impl_error_trait = gen_impl_error_trait(&error_type_name);
+    let definition = gen_definition(error_type_name, validators);
+    let impl_display_trait = gen_impl_display_trait(type_name, error_type_name, validators);
+    let impl_error_trait = gen_impl_error_trait(error_type_name);
 
     quote! {
         #[derive(Debug, Clone, PartialEq, Eq)]

--- a/nutype_macros/src/string/gen/traits/arbitrary.rs
+++ b/nutype_macros/src/string/gen/traits/arbitrary.rs
@@ -111,6 +111,7 @@ fn build_specification(guard: &StringGuard) -> Result<Option<Specification>, syn
         StringGuard::WithValidation {
             sanitizers,
             validators,
+            error_type_name: _,
         } => {
             let relevant_sanitizers = filter_sanitizers(sanitizers)?;
             let relevant_validators = filter_validators(validators)?;

--- a/nutype_macros/src/string/gen/traits/mod.rs
+++ b/nutype_macros/src/string/gen/traits/mod.rs
@@ -139,7 +139,6 @@ impl ToTokens for StringTransparentTrait {
 pub fn gen_traits(
     type_name: &TypeName,
     generics: &Generics,
-    maybe_error_type_name: Option<ErrorTypeName>,
     traits: HashSet<StringDeriveTrait>,
     maybe_default_value: Option<syn::Expr>,
     guard: &StringGuard,
@@ -158,7 +157,6 @@ pub fn gen_traits(
     let implement_traits = gen_implemented_traits(
         type_name,
         generics,
-        maybe_error_type_name,
         maybe_default_value,
         irregular_traits,
         guard,
@@ -173,12 +171,12 @@ pub fn gen_traits(
 fn gen_implemented_traits(
     type_name: &TypeName,
     generics: &Generics,
-    maybe_error_type_name: Option<ErrorTypeName>,
     maybe_default_value: Option<syn::Expr>,
     impl_traits: Vec<StringIrregularTrait>,
     guard: &StringGuard,
 ) -> Result<TokenStream, syn::Error> {
     let inner_type = StringInnerType;
+    let maybe_error_type_name = guard.maybe_error_type_name();
 
     impl_traits
         .iter()
@@ -186,12 +184,12 @@ fn gen_implemented_traits(
             StringIrregularTrait::AsRef => Ok(gen_impl_trait_as_ref(type_name, generics, quote!(str))),
             StringIrregularTrait::Deref => Ok(gen_impl_trait_deref(type_name, generics, quote!(String))),
             StringIrregularTrait::FromStr => {
-                Ok(gen_impl_from_str(type_name, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_from_str(type_name, maybe_error_type_name))
             }
             StringIrregularTrait::From => Ok(gen_impl_from_str_and_string(type_name)),
             StringIrregularTrait::Into => Ok(gen_impl_trait_into(type_name, &Generics::default(), inner_type)),
             StringIrregularTrait::TryFrom => {
-                Ok(gen_impl_try_from(type_name, maybe_error_type_name.as_ref()))
+                Ok(gen_impl_try_from(type_name, maybe_error_type_name))
             }
             StringIrregularTrait::Borrow => Ok(gen_impl_borrow_str_and_string(type_name)),
             StringIrregularTrait::Display => Ok(gen_impl_trait_display(type_name, &Generics::default())),
@@ -216,7 +214,7 @@ fn gen_implemented_traits(
                 type_name,
                 generics,
                 inner_type,
-                maybe_error_type_name.as_ref(),
+                maybe_error_type_name,
             )),
             StringIrregularTrait::ArbitraryArbitrary => {
                 arbitrary::gen_impl_trait_arbitrary(type_name, guard)

--- a/nutype_macros/src/string/mod.rs
+++ b/nutype_macros/src/string/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use crate::common::{
     gen::GenerateNewtype,
-    models::{Attributes, GenerateParams, Newtype, SpannedDeriveTrait},
+    models::{Attributes, GenerateParams, Newtype, SpannedDeriveTrait, TypeName},
 };
 
 use models::{StringDeriveTrait, StringSanitizer, StringValidator};
@@ -28,8 +28,9 @@ impl Newtype for StringNewtype {
 
     fn parse_attributes(
         attrs: TokenStream,
+        type_name: &TypeName,
     ) -> Result<Attributes<StringGuard, SpannedDeriveTrait>, syn::Error> {
-        parse::parse_attributes(attrs)
+        parse::parse_attributes(attrs, type_name)
     }
 
     fn validate(

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{
-        models::{Attributes, SpannedDeriveTrait, SpannedItem},
+        models::{Attributes, SpannedDeriveTrait, SpannedItem, TypeName},
         parse::{
             parse_number_or_expr, parse_sanitizer_kind, parse_typed_custom_function_raw,
             parse_validator_kind, ParseableAttributes,
@@ -21,11 +21,12 @@ use super::{
         RegexDef, SpannedStringSanitizer, SpannedStringValidator, StringSanitizerKind,
         StringValidatorKind,
     },
-    validate::validate_string_meta,
+    validate::validate_string_guard,
 };
 
 pub fn parse_attributes(
     input: TokenStream,
+    type_name: &TypeName,
 ) -> Result<Attributes<StringGuard, SpannedDeriveTrait>, syn::Error> {
     let attrs: ParseableAttributes<SpannedStringSanitizer, SpannedStringValidator> =
         syn::parse2(input)?;
@@ -36,12 +37,14 @@ pub fn parse_attributes(
         new_unchecked,
         default,
         derive_traits,
+        error_type_name,
     } = attrs;
     let raw_guard = StringRawGuard {
         sanitizers,
         validators,
+        error_type_name,
     };
-    let guard = validate_string_meta(raw_guard)?;
+    let guard = validate_string_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
         guard,

--- a/nutype_macros/src/string/validate.rs
+++ b/nutype_macros/src/string/validate.rs
@@ -5,8 +5,8 @@ use proc_macro2::Span;
 
 use crate::{
     common::{
-        models::{DeriveTrait, SpannedDeriveTrait, ValueOrExpr},
-        validate::{validate_duplicates, validate_traits_from_xor_try_from},
+        models::{DeriveTrait, SpannedDeriveTrait, TypeName, ValueOrExpr},
+        validate::{validate_duplicates, validate_guard, validate_traits_from_xor_try_from},
     },
     string::models::{StringGuard, StringRawGuard, StringSanitizer, StringValidator},
 };
@@ -15,23 +15,16 @@ use super::models::{
     SpannedStringSanitizer, SpannedStringValidator, StringDeriveTrait, StringSanitizerKind,
 };
 
-pub fn validate_string_meta(raw_meta: StringRawGuard) -> Result<StringGuard, syn::Error> {
-    let StringRawGuard {
-        sanitizers,
-        validators,
-    } = raw_meta;
-
-    let validators = validate_validators(validators)?;
-    let sanitizers = validate_sanitizers(sanitizers)?;
-
-    if validators.is_empty() {
-        Ok(StringGuard::WithoutValidation { sanitizers })
-    } else {
-        Ok(StringGuard::WithValidation {
-            sanitizers,
-            validators,
-        })
-    }
+pub fn validate_string_guard(
+    raw_guard: StringRawGuard,
+    type_name: &TypeName,
+) -> Result<StringGuard, syn::Error> {
+    validate_guard(
+        raw_guard,
+        type_name,
+        validate_validators,
+        validate_sanitizers,
+    )
 }
 
 fn validate_validators(

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -68,7 +68,7 @@ mod traits {
     #[test]
     fn test_clone() {
         let location = Location::new(Point::new(5, 8));
-        let same_location = location.clone();
+        let same_location = location;
 
         assert_eq!(location.into_inner(), same_location.into_inner(),);
     }
@@ -679,7 +679,7 @@ mod with_generics {
         #[nutype(derive(Debug, From))]
         struct Doener<T>(T);
 
-        let durum = Doener::try_from("Durum").unwrap();
+        let durum = Doener::from("Durum");
         assert_eq!(durum.into_inner(), "Durum");
     }
 
@@ -773,7 +773,7 @@ mod with_generics {
         struct Arbaro<T>(Vec<T>);
 
         fn gen(bytes: &[u8]) -> Vec<bool> {
-            let mut u = arbitrary::Unstructured::new(&bytes);
+            let mut u = arbitrary::Unstructured::new(bytes);
             let arbraro = Arbaro::<bool>::arbitrary(&mut u).unwrap();
             arbraro.into_inner()
         }

--- a/test_suite/tests/float.rs
+++ b/test_suite/tests/float.rs
@@ -582,7 +582,7 @@ mod traits {
                     Ok(())
                 }
 
-                arbtest::builder().run(|u| prop(u));
+                arbtest::builder().run(prop);
             }
 
             #[test]
@@ -600,7 +600,7 @@ mod traits {
                     Ok(())
                 }
 
-                arbtest::builder().run(|u| prop(u));
+                arbtest::builder().run(prop);
             }
         }
     }

--- a/test_suite/tests/string.rs
+++ b/test_suite/tests/string.rs
@@ -386,7 +386,7 @@ mod derives {
 
         // Let's do something with deref-coercion:
         assert_eq!(name.len(), 4);
-        assert_eq!(name.is_empty(), false);
+        assert!(!name.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
This refactor is necessary to enable custom error types (https://github.com/greyblake/nutype/issues/161)