### PR TITLE
allow implementing `core::error::Error` when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
+ "rustc_version",
  "syn 2.0.66",
  "urlencoding",
 ]
@@ -427,6 +428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +465,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"

--- a/nutype_macros/Cargo.toml
+++ b/nutype_macros/Cargo.toml
@@ -26,6 +26,12 @@ cfg-if = "1.0"
 kinded = "0.3.0"
 urlencoding = "2.0"
 
+[build-dependencies]
+rustc_version = "0.4.1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ERROR_IN_CORE)'] }
+
 [lib]
 proc-macro = true
 

--- a/nutype_macros/build.rs
+++ b/nutype_macros/build.rs
@@ -1,0 +1,20 @@
+use rustc_version::{version, version_meta, Channel};
+
+fn main() {
+    let version = version().expect("Couldn't get Rust version");
+    let version_meta = version_meta().expect("Couldn't get Rust channel");
+
+    // Assert we haven't travelled back in time
+    assert!(
+        version.major >= 1,
+        "How did you get a version before 1.0.0?"
+    );
+
+    // Generic setting
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // feature `error-in-core` landed in rust 1.81.0
+    if matches!(version_meta.channel, Channel::Nightly) || version.minor >= 81 {
+        println!("cargo:rustc-cfg=ERROR_IN_CORE");
+    }
+}

--- a/nutype_macros/src/common/gen/error.rs
+++ b/nutype_macros/src/common/gen/error.rs
@@ -11,12 +11,19 @@ pub fn gen_error_type_name(type_name: &TypeName) -> ErrorTypePath {
     ErrorTypePath::new(ident)
 }
 
-// NOTE: There is no `::core::error::Error` yet in stable Rust.
-// So for `no_std` we just don't implement `Error` trait.
+// NOTE: `::core::error::Error` is stable only for rust >= 1.81.0.
 #[allow(unused_variables)]
 pub fn gen_impl_error_trait(error_type_path: &ErrorTypePath) -> TokenStream {
     cfg_if! {
-        if #[cfg(feature = "std")] {
+        if #[cfg(ERROR_IN_CORE)] {
+            quote! {
+                impl ::core::error::Error for #error_type_name {
+                    fn source(&self) -> Option<&(dyn ::core::error::Error + 'static)> {
+                        None
+                    }
+                }
+            }
+        } else if #[cfg(feature = "std")] {
             quote! {
                 impl ::std::error::Error for #error_type_path {
                     fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {

--- a/nutype_macros/src/common/gen/error.rs
+++ b/nutype_macros/src/common/gen/error.rs
@@ -15,18 +15,18 @@ pub fn gen_error_type_name(type_name: &TypeName) -> ErrorTypePath {
 #[allow(unused_variables)]
 pub fn gen_impl_error_trait(error_type_path: &ErrorTypePath) -> TokenStream {
     cfg_if! {
-        if #[cfg(ERROR_IN_CORE)] {
-            quote! {
-                impl ::core::error::Error for #error_type_name {
-                    fn source(&self) -> Option<&(dyn ::core::error::Error + 'static)> {
-                        None
-                    }
+        if #[cfg(any(ERROR_IN_CORE, feature = "std"))] {
+            cfg_if! {
+                if #[cfg(ERROR_IN_CORE)] {
+                    let error = quote! { ::core::error::Error };
+                } else {
+                    let error = quote! { ::std::error::Error };
                 }
-            }
-        } else if #[cfg(feature = "std")] {
+            };
+
             quote! {
-                impl ::std::error::Error for #error_type_path {
-                    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+                impl #error for #error_type_path {
+                    fn source(&self) -> Option<&(dyn #error + 'static)> {
                         None
                     }
                 }

--- a/nutype_macros/src/common/gen/parse_error.rs
+++ b/nutype_macros/src/common/gen/parse_error.rs
@@ -68,26 +68,21 @@ pub fn gen_def_parse_error(
     };
 
     cfg_if! {
-        if #[cfg(ERROR_IN_CORE)] {
-            let generics_with_fromstr_and_debug_bounds = add_bound_to_all_type_params(
-                &generics_with_fromstr_bound,
-                syn::parse_quote!(::core::fmt::Debug),
-            );
-            let impl_error = quote! {
-                impl #generics_with_fromstr_and_debug_bounds ::core::error::Error for #parse_error_type_name #generics_without_bounds {
-                    fn source(&self) -> Option<&(dyn ::core::error::Error + 'static)> {
-                        None
-                    }
+        if #[cfg(any(ERROR_IN_CORE, feature = "std"))] {
+            cfg_if! {
+                if #[cfg(ERROR_IN_CORE)] {
+                    let error = quote! { ::core::error::Error };
+                } else {
+                    let error = quote! { ::std::error::Error };
                 }
             };
-        } else if #[cfg(feature = "std")] {
             let generics_with_fromstr_and_debug_bounds = add_bound_to_all_type_params(
                 &generics_with_fromstr_bound,
                 syn::parse_quote!(::core::fmt::Debug),
             );
             let impl_error = quote! {
-                impl #generics_with_fromstr_and_debug_bounds ::std::error::Error for #parse_error_type_name #generics_without_bounds {
-                    fn source(&self) -> Option<&(dyn ::std::error::Error + 'static)> {
+                impl #generics_with_fromstr_and_debug_bounds #error for #parse_error_type_name #generics_without_bounds {
+                    fn source(&self) -> Option<&(dyn #error + 'static)> {
                         None
                     }
                 }


### PR DESCRIPTION
rust 1.81.0 made `std::error::Error` available in core.
Users with that version or higher should be getting the `Error` impl no matter if `std` feature is enabled.
fixes #179 without introducing a breaking change
