### PR TITLE
add `tests` module around generated tests

### DIFF
--- a/nutype_macros/src/common/gen/mod.rs
+++ b/nutype_macros/src/common/gen/mod.rs
@@ -453,7 +453,11 @@ pub trait GenerateNewtype {
                 #implementation
                 #implement_traits
 
-                #tests
+                #[cfg(test)]
+                mod tests {
+                    use super::*;
+                    #tests
+                }
             }
             #reimports
         ))


### PR DESCRIPTION
rust analyzer in VSCode complains about generated tests not being inside a `#[cfg(test)]` module, this PR fixes that.

<img width="946" alt="{8F382B25-2DB4-41F8-8F80-8EFC8FADFE75}" src="https://github.com/user-attachments/assets/55d7283b-8498-4b0f-952f-27622eaca828">
