### PR TITLE
make `__nutype_{type_name}__` compatible with clippy lint

### DIFF
--- a/nutype_macros/src/common/gen/mod.rs
+++ b/nutype_macros/src/common/gen/mod.rs
@@ -443,6 +443,7 @@ pub trait GenerateNewtype {
 
         Ok(quote!(
             #[doc(hidden)]
+            #[allow(non_snake_case, reason = "we keep original structure name which is probably CamelCase")]
             mod #module_name {
                 use super::*;
 


### PR DESCRIPTION
rust analyzer in VSCode complains about generated nutype module not being proper snake case, this PR fixes that with a naive to_lower_case call as I think nobody really cares about how exactly it is named except clippy x).

<img width="772" alt="{FF067F22-4979-41A5-ABAC-D9099C9E9C7E}" src="https://github.com/user-attachments/assets/aa6f5acc-031e-47b7-944e-ac9b7bd87329">
