### PR TITLE
Ability to generate associated consts

### DIFF
--- a/nutype_macros/src/any/gen/mod.rs
+++ b/nutype_macros/src/any/gen/mod.rs
@@ -9,9 +9,11 @@ use syn::{parse_quote, Generics};
 
 use crate::common::{
     gen::{
-        tests::gen_test_should_have_valid_default_value, traits::GeneratedTraits, GenerateNewtype,
+        tests::{gen_associated_consts_should_be_valid, gen_test_should_have_valid_default_value},
+        traits::GeneratedTraits,
+        GenerateNewtype,
     },
-    models::{ErrorTypePath, Guard, TypeName, TypedCustomFunction},
+    models::{ConstAssign, ErrorTypePath, Guard, TypeName, TypedCustomFunction},
 };
 
 use self::error::gen_validation_error_type;
@@ -138,6 +140,7 @@ impl GenerateNewtype for AnyNewtype {
         maybe_default_value: &Option<syn::Expr>,
         guard: &Guard<Self::Sanitizer, Self::Validator>,
         _traits: &HashSet<Self::TypedTrait>,
+        associated_consts: &[ConstAssign],
     ) -> TokenStream {
         let test_valid_default_value = gen_test_should_have_valid_default_value(
             type_name,
@@ -145,9 +148,12 @@ impl GenerateNewtype for AnyNewtype {
             maybe_default_value,
             guard.has_validation(),
         );
+        let test_associated_consts =
+            gen_associated_consts_should_be_valid(type_name, associated_consts);
 
         quote! {
             #test_valid_default_value
+            #test_associated_consts
         }
     }
 }

--- a/nutype_macros/src/any/parse.rs
+++ b/nutype_macros/src/any/parse.rs
@@ -28,6 +28,7 @@ pub fn parse_attributes(
         new_unchecked,
         default,
         derive_traits,
+        associated_consts,
     } = attrs;
     let raw_guard = AnyRawGuard {
         sanitizers,
@@ -39,6 +40,7 @@ pub fn parse_attributes(
         guard,
         default,
         derive_traits,
+        associated_consts,
     })
 }
 

--- a/nutype_macros/src/common/gen/associated_consts.rs
+++ b/nutype_macros/src/common/gen/associated_consts.rs
@@ -1,0 +1,33 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Generics;
+
+use crate::common::{
+    gen::strip_trait_bounds_on_generics,
+    models::{ConstAssign, TypeName},
+};
+
+pub fn gen_associated_consts(
+    type_name: &TypeName,
+    generics: &Generics,
+    associated_consts: &[ConstAssign],
+) -> TokenStream {
+    let generics_without_bounds = strip_trait_bounds_on_generics(generics);
+    let consts = associated_consts.iter().map(
+        |ConstAssign {
+             const_name,
+             const_value,
+             ..
+         }| {
+            quote! {
+                pub const #const_name: Self = Self(#const_value);
+            }
+        },
+    );
+
+    quote! {
+        impl #generics #type_name #generics_without_bounds {
+            #(#consts)*
+        }
+    }
+}

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -16,13 +16,14 @@ use crate::{
     common::{
         gen::{
             tests::{
+                gen_associated_consts_should_be_valid,
                 gen_test_should_have_consistent_lower_and_upper_boundaries,
                 gen_test_should_have_valid_default_value,
             },
             traits::GeneratedTraits,
             GenerateNewtype,
         },
-        models::{ErrorTypePath, Guard, TypeName},
+        models::{ConstAssign, ErrorTypePath, Guard, TypeName},
     },
     float::models::FloatInnerType,
 };
@@ -158,6 +159,7 @@ where
         maybe_default_value: &Option<syn::Expr>,
         guard: &Guard<Self::Sanitizer, Self::Validator>,
         _traits: &HashSet<Self::TypedTrait>,
+        associated_consts: &[ConstAssign],
     ) -> TokenStream {
         let test_lower_vs_upper = guard.standard_validators().and_then(|validators| {
             gen_test_should_have_consistent_lower_and_upper_boundaries(type_name, validators)
@@ -170,9 +172,13 @@ where
             guard.has_validation(),
         );
 
+        let test_associated_consts =
+            gen_associated_consts_should_be_valid(type_name, associated_consts);
+
         quote! {
             #test_lower_vs_upper
             #test_valid_default_value
+            #test_associated_consts
         }
     }
 }

--- a/nutype_macros/src/float/parse.rs
+++ b/nutype_macros/src/float/parse.rs
@@ -41,6 +41,7 @@ where
         new_unchecked,
         default,
         derive_traits,
+        associated_consts,
     } = attrs;
     let raw_guard = FloatRawGuard {
         sanitizers,
@@ -52,6 +53,7 @@ where
         guard,
         default,
         derive_traits,
+        associated_consts,
     })
 }
 

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -18,13 +18,14 @@ use super::{
 use crate::common::{
     gen::{
         tests::{
+            gen_associated_consts_should_be_valid,
             gen_test_should_have_consistent_lower_and_upper_boundaries,
             gen_test_should_have_valid_default_value,
         },
         traits::GeneratedTraits,
         GenerateNewtype,
     },
-    models::{ErrorTypePath, Guard, TypeName},
+    models::{ConstAssign, ErrorTypePath, Guard, TypeName},
 };
 
 impl<T> GenerateNewtype for IntegerNewtype<T>
@@ -150,6 +151,7 @@ where
         maybe_default_value: &Option<syn::Expr>,
         guard: &Guard<Self::Sanitizer, Self::Validator>,
         _traits: &HashSet<Self::TypedTrait>,
+        associated_consts: &[ConstAssign],
     ) -> TokenStream {
         let test_lower_vs_upper = guard.standard_validators().and_then(|validators| {
             gen_test_should_have_consistent_lower_and_upper_boundaries(type_name, validators)
@@ -162,9 +164,13 @@ where
             guard.has_validation(),
         );
 
+        let test_associated_consts =
+            gen_associated_consts_should_be_valid(type_name, associated_consts);
+
         quote! {
             #test_lower_vs_upper
             #test_valid_default_value
+            #test_associated_consts
         }
     }
 }

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -41,6 +41,7 @@ where
         new_unchecked,
         default,
         derive_traits,
+        associated_consts,
     } = attrs;
     let raw_guard = IntegerRawGuard {
         sanitizers,
@@ -52,6 +53,7 @@ where
         guard,
         default,
         derive_traits,
+        associated_consts,
     })
 }
 

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -11,10 +11,13 @@ use syn::Generics;
 use crate::{
     common::{
         gen::{
-            tests::gen_test_should_have_valid_default_value, traits::GeneratedTraits,
+            tests::{
+                gen_associated_consts_should_be_valid, gen_test_should_have_valid_default_value,
+            },
+            traits::GeneratedTraits,
             GenerateNewtype,
         },
-        models::{ErrorTypePath, Guard, TypeName},
+        models::{ConstAssign, ErrorTypePath, Guard, TypeName},
     },
     string::models::{RegexDef, StringInnerType, StringSanitizer, StringValidator},
 };
@@ -189,6 +192,7 @@ impl GenerateNewtype for StringNewtype {
         maybe_default_value: &Option<syn::Expr>,
         guard: &Guard<Self::Sanitizer, Self::Validator>,
         _traits: &HashSet<Self::TypedTrait>,
+        associated_consts: &[ConstAssign],
     ) -> TokenStream {
         let test_len_char_min_vs_max = guard.standard_validators().and_then(|validators| {
             tests::gen_test_should_have_consistent_len_char_boundaries(type_name, validators)
@@ -201,9 +205,13 @@ impl GenerateNewtype for StringNewtype {
             guard.has_validation(),
         );
 
+        let test_associated_consts =
+            gen_associated_consts_should_be_valid(type_name, associated_consts);
+
         quote! {
             #test_len_char_min_vs_max
             #test_valid_default_value
+            #test_associated_consts
         }
     }
 }

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -37,6 +37,7 @@ pub fn parse_attributes(
         new_unchecked,
         default,
         derive_traits,
+        associated_consts,
     } = attrs;
     let raw_guard = StringRawGuard {
         sanitizers,
@@ -48,6 +49,7 @@ pub fn parse_attributes(
         guard,
         default,
         derive_traits,
+        associated_consts,
     })
 }
 


### PR DESCRIPTION
This PR makes it possible to do, inspiration taken from https://github.com/greyblake/nutype/issues/35

```rs
use nutype::nutype;

#[nutype(
	validate(finite, greater = 0.0),
	consts(
		ONE = 1.0,
		TWO = 2.0_f32,
		SUM = 1.0 + 4.0,
		INVALID_LESSER = -1.0,
		INVALID_FINITE = f32::NAN,
		FROM_CONST_FN = get_static_f32(),
		// and pretty much anything else
	),
)]
pub struct FinitePositiveFloat(f32);
```
Tests are generated in order to ensure that those consts are valid.

TODO:
[ ] make `consts` only available to ints and floats. Strings simply can't. But how about any other datatypes ?
[ ] changelog & docs
[ ] any ideas ? @greyblake 
