### PR TITLE
refactor: call the trait method instead of the instance method

### DIFF
--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -276,7 +276,7 @@ pub fn gen_impl_trait_serde_serialize(type_name: &TypeName, generics: &Generics)
             where
                 S: ::serde::Serializer
             {
-                serializer.serialize_newtype_struct(#type_name_str, &self.0)
+                ::serde::ser::Serializer::serialize_newtype_struct(serializer, #type_name_str, &self.0)
             }
         }
     }


### PR DESCRIPTION
Hi!

First of all, thank you for this cool crate.

Recently I have worked on implementing support for the `borsh` crate to make it possible to derive its traits using `nutype`.
While working on it, I encountered the error that it is impossible to derive both `serde` and `borsh` traits.
This was because I used instance methods, and there was a conflict of `serialize` method implementations.
I solved this using the original trait method, and now everything works fine.

This little change is supposed to avoid such problems in future features.
Also, this will improve code consistency because such an approach is already used in the `Deserialize` trait implementation.

```rs
::serde::de::Deserializer::deserialize_newtype_struct(
    deserializer,
    #type_name_str,
    __Visitor {
        marker: Default::default(),
        lifetime: Default::default(),
    }
)
```