### PR TITLE
Const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "const_example"
+version = "0.1.0"
+dependencies = [
+ "nutype",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ members = [
     "examples/string_arbitrary",
     "examples/any_generics",
     "examples/custom_error",
+    "examples/const_example",
 ]

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,35 +1,25 @@
 use nutype::nutype;
 
-fn validate_name(name: &str) -> Result<(), NameError> {
-    if name.len() < 3 {
-        Err(NameError::TooShort)
-    } else if name.len() > 10 {
-        Err(NameError::TooLong)
-    } else {
-        Ok(())
+#[nutype(
+    const_fn,
+    derive(Debug),
+    validate(greater_or_equal = -273.15),
+)]
+pub struct Celsius(f64);
+
+impl Celsius {
+    pub const fn new_const(value: f64) -> Self {
+        match Self::try_new(value) {
+            Ok(value) => value,
+            Err(_e) => {
+                panic!("Failed to create Celsius");
+            }
+        }
     }
 }
 
-#[derive(Debug, PartialEq)]
-enum NameError {
-    TooShort,
-    TooLong,
-}
-
-#[nutype(
-    validate(with = validate_name, error = NameError),
-    derive(Debug, AsRef, PartialEq),
-)]
-struct Name(String);
+const WATER_BOILING_POINT: Celsius = Celsius::new_const(100.0);
 
 fn main() {
-    let name = Name::try_new("John").unwrap();
-    assert_eq!(name.as_ref(), "John");
-
-    assert_eq!(
-        Name::try_new("JohnJohnJohnJohnJohn"),
-        Err(NameError::TooLong)
-    );
-
-    assert_eq!(Name::try_new("Jo"), Err(NameError::TooShort));
+    println!("{:?}", WATER_BOILING_POINT);
 }

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -7,18 +7,16 @@ use nutype::nutype;
 )]
 pub struct Celsius(f64);
 
-impl Celsius {
-    pub const fn new_const(value: f64) -> Self {
-        match Self::try_new(value) {
+macro_rules! nutype_const {
+    ($name:ident, $ty:ty, $value:expr) => {
+        const $name: $ty = match <$ty>::try_new($value) {
             Ok(value) => value,
-            Err(_e) => {
-                panic!("Failed to create Celsius");
-            }
-        }
-    }
+            Err(_) => panic!("Invalid value"),
+        };
+    };
 }
 
-const WATER_BOILING_POINT: Celsius = Celsius::new_const(100.0);
+nutype_const!(WATER_BOILING_POINT, Celsius, 100.0);
 
 fn main() {
     println!("{:?}", WATER_BOILING_POINT);

--- a/examples/const_example/Cargo.toml
+++ b/examples/const_example/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "const_example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nutype = { path = "../../nutype", features = ["new_unchecked"] }

--- a/examples/const_example/src/main.rs
+++ b/examples/const_example/src/main.rs
@@ -1,6 +1,7 @@
 // Adding `const_fn` flag to #[nutype] macro will make the generated `new` and `try_new` functions
 // be marked with `const` keyword.
 use nutype::nutype;
+use std::sync::LazyLock;
 
 #[nutype(const_fn, validate(greater_or_equal = 18))]
 pub struct Age(u8);
@@ -41,8 +42,16 @@ struct TaxClass(u8);
 
 const DEFAULT_TAX_CLASS: TaxClass = unsafe { TaxClass::new_unchecked(1) };
 
+// Heap allocated types cannot be used as const,
+// so for that purpose one could use LazyLock from std::sync.
+#[nutype(derive(Debug, AsRef), validate(not_empty))]
+pub struct Name(String);
+
+const DEFAULT_NAME: LazyLock<Name> = LazyLock::new(|| Name::try_new("John".to_string()).unwrap());
+
 fn main() {
     assert_eq!(PENSION_AGE.into_inner(), 67);
     assert_eq!(DEFAULT_TAX_CLASS.into_inner(), 1);
     assert_eq!(MAX_CORRELATION.into_inner(), 1.0);
+    assert_eq!(DEFAULT_NAME.as_ref(), "John");
 }

--- a/examples/const_example/src/main.rs
+++ b/examples/const_example/src/main.rs
@@ -12,6 +12,25 @@ const PENSION_AGE: Age = match Age::try_new(67) {
     Err(_) => panic!("Invalid Age"),
 };
 
+// Until `const` functions are stabilized, we recommend to  define in application
+// and reuse `nutype_const!` macro to create constants from `nutype` types
+#[nutype(
+    const_fn,
+    validate(greater_or_equal = -1.0, less_or_equal = 1.0)
+)]
+struct Correlation(f32);
+
+macro_rules! nutype_const {
+    ($name:ident, $ty:ty, $value:expr) => {
+        const $name: $ty = match <$ty>::try_new($value) {
+            Ok(value) => value,
+            Err(_) => panic!("Invalid value"),
+        };
+    };
+}
+
+nutype_const!(MAX_CORRELATION, Correlation, 1.0);
+
 // Not recommended, but it's possible to use `new_unchecked` with `const_fn` flag.
 #[nutype(
     const_fn,
@@ -25,4 +44,5 @@ const DEFAULT_TAX_CLASS: TaxClass = unsafe { TaxClass::new_unchecked(1) };
 fn main() {
     assert_eq!(PENSION_AGE.into_inner(), 67);
     assert_eq!(DEFAULT_TAX_CLASS.into_inner(), 1);
+    assert_eq!(MAX_CORRELATION.into_inner(), 1.0);
 }

--- a/examples/const_example/src/main.rs
+++ b/examples/const_example/src/main.rs
@@ -1,0 +1,28 @@
+// Adding `const_fn` flag to #[nutype] macro will make the generated `new` and `try_new` functions
+// be marked with `const` keyword.
+use nutype::nutype;
+
+#[nutype(const_fn, validate(greater_or_equal = 18))]
+pub struct Age(u8);
+
+// Unfortunately `Result::unwrap` is not a `const` function, so we have
+// to unwrap it ourselves.
+const PENSION_AGE: Age = match Age::try_new(67) {
+    Ok(age) => age,
+    Err(_) => panic!("Invalid Age"),
+};
+
+// Not recommended, but it's possible to use `new_unchecked` with `const_fn` flag.
+#[nutype(
+    const_fn,
+    new_unchecked,
+    validate(greater_or_equal = 1, less_or_equal = 6,)
+)]
+struct TaxClass(u8);
+
+const DEFAULT_TAX_CLASS: TaxClass = unsafe { TaxClass::new_unchecked(1) };
+
+fn main() {
+    assert_eq!(PENSION_AGE.into_inner(), 67);
+    assert_eq!(DEFAULT_TAX_CLASS.into_inner(), 1);
+}

--- a/examples/const_example/src/main.rs
+++ b/examples/const_example/src/main.rs
@@ -1,7 +1,6 @@
 // Adding `const_fn` flag to #[nutype] macro will make the generated `new` and `try_new` functions
 // be marked with `const` keyword.
 use nutype::nutype;
-use std::sync::LazyLock;
 
 #[nutype(const_fn, validate(greater_or_equal = 18))]
 pub struct Age(u8);
@@ -42,16 +41,8 @@ struct TaxClass(u8);
 
 const DEFAULT_TAX_CLASS: TaxClass = unsafe { TaxClass::new_unchecked(1) };
 
-// Heap allocated types cannot be used as const,
-// so for that purpose one could use LazyLock from std::sync.
-#[nutype(derive(Debug, AsRef), validate(not_empty))]
-pub struct Name(String);
-
-const DEFAULT_NAME: LazyLock<Name> = LazyLock::new(|| Name::try_new("John".to_string()).unwrap());
-
 fn main() {
     assert_eq!(PENSION_AGE.into_inner(), 67);
     assert_eq!(DEFAULT_TAX_CLASS.into_inner(), 1);
     assert_eq!(MAX_CORRELATION.into_inner(), 1.0);
-    assert_eq!(DEFAULT_NAME.as_ref(), "John");
 }

--- a/nutype_macros/src/any/gen/mod.rs
+++ b/nutype_macros/src/any/gen/mod.rs
@@ -11,7 +11,7 @@ use crate::common::{
     gen::{
         tests::gen_test_should_have_valid_default_value, traits::GeneratedTraits, GenerateNewtype,
     },
-    models::{ErrorTypePath, Guard, TypeName, TypedCustomFunction},
+    models::{ConstFn, ErrorTypePath, Guard, TypeName, TypedCustomFunction},
 };
 
 use self::error::gen_validation_error_type;
@@ -32,6 +32,7 @@ impl GenerateNewtype for AnyNewtype {
     fn gen_fn_sanitize(
         inner_type: &Self::InnerType,
         sanitizers: &[Self::Sanitizer],
+        const_fn: ConstFn,
     ) -> TokenStream {
         let transformations: TokenStream = sanitizers
             .iter()
@@ -52,7 +53,7 @@ impl GenerateNewtype for AnyNewtype {
             .collect();
 
         quote!(
-            fn __sanitize__(mut value: #inner_type) -> #inner_type {
+            #const_fn fn __sanitize__(mut value: #inner_type) -> #inner_type {
                 #transformations
                 value
             }
@@ -63,6 +64,7 @@ impl GenerateNewtype for AnyNewtype {
         inner_type: &Self::InnerType,
         error_type_path: &ErrorTypePath,
         validators: &[Self::Validator],
+        const_fn: ConstFn,
     ) -> TokenStream {
         let validations: TokenStream = validators
             .iter()
@@ -98,7 +100,7 @@ impl GenerateNewtype for AnyNewtype {
             // Since this code is generic which is used for different inner types (not only Cow), we cannot easily fix it to make
             // clippy happy.
             #[allow(clippy::ptr_arg)]
-            fn __validate__<'nutype_a>(val: &'nutype_a #inner_type) -> ::core::result::Result<(), #error_type_path> {
+            #const_fn fn __validate__<'nutype_a>(val: &'nutype_a #inner_type) -> ::core::result::Result<(), #error_type_path> {
                 #validations
                 Ok(())
             }

--- a/nutype_macros/src/any/parse.rs
+++ b/nutype_macros/src/any/parse.rs
@@ -26,6 +26,7 @@ pub fn parse_attributes(
         sanitizers,
         validation,
         new_unchecked,
+        const_fn,
         default,
         derive_traits,
     } = attrs;
@@ -36,6 +37,7 @@ pub fn parse_attributes(
     let guard = validate_any_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
+        const_fn,
         guard,
         default,
         derive_traits,

--- a/nutype_macros/src/common/gen/new_unchecked.rs
+++ b/nutype_macros/src/common/gen/new_unchecked.rs
@@ -1,4 +1,4 @@
-use crate::common::models::{NewUnchecked, TypeName};
+use crate::common::models::{ConstFn, NewUnchecked, TypeName};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
@@ -6,6 +6,7 @@ pub fn gen_new_unchecked(
     type_name: &TypeName,
     inner_type: impl ToTokens,
     new_unchecked: NewUnchecked,
+    const_fn: ConstFn,
 ) -> TokenStream {
     match new_unchecked {
         NewUnchecked::Off => quote! {},
@@ -14,7 +15,7 @@ pub fn gen_new_unchecked(
                 /// Creates a value of type skipping the sanitization and validation
                 /// rules. Generally, you should avoid using `::new_unchecked()` without a real need.
                 /// Use `::new()` instead when it's possible.
-                pub unsafe fn new_unchecked(inner_value: #inner_type) -> #type_name {
+                pub #const_fn unsafe fn new_unchecked(inner_value: #inner_type) -> #type_name {
                     #type_name(inner_value)
                 }
             }

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -259,6 +259,9 @@ pub struct Attributes<G, DT> {
     /// `new_unchecked` flag
     pub new_unchecked: NewUnchecked,
 
+    /// `const_fn` flag
+    pub const_fn: ConstFn,
+
     /// Value for Default trait. Provide with `default = `
     pub default: Option<syn::Expr>,
 
@@ -386,6 +389,26 @@ pub enum NewUnchecked {
     On,
 }
 
+/// The flag that indicates the functions must be generated with `const_fn` keyword.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ConstFn {
+    #[default]
+    NoConst,
+
+    Const,
+}
+
+impl ToTokens for ConstFn {
+    fn to_tokens(&self, token_stream: &mut TokenStream) {
+        match self {
+            Self::NoConst => {}
+            Self::Const => {
+                quote!(const).to_tokens(token_stream);
+            }
+        };
+    }
+}
+
 pub struct GenerateParams<IT, Trait, Guard> {
     pub inner_type: IT,
     pub doc_attrs: Vec<Attribute>,
@@ -395,6 +418,7 @@ pub struct GenerateParams<IT, Trait, Guard> {
     pub generics: Generics,
     pub guard: Guard,
     pub new_unchecked: NewUnchecked,
+    pub const_fn: ConstFn,
     pub maybe_default_value: Option<syn::Expr>,
 }
 
@@ -438,6 +462,7 @@ pub trait Newtype {
         let Attributes {
             guard,
             new_unchecked,
+            const_fn,
             default: maybe_default_value,
             derive_traits,
         } = Self::parse_attributes(attrs, &type_name)?;
@@ -450,6 +475,7 @@ pub trait Newtype {
             generics,
             guard,
             new_unchecked,
+            const_fn,
             maybe_default_value,
             inner_type,
         })?;

--- a/nutype_macros/src/common/parse/mod.rs
+++ b/nutype_macros/src/common/parse/mod.rs
@@ -21,7 +21,7 @@ use syn::{
 use crate::common::models::SpannedDeriveTrait;
 
 use super::models::{
-    CustomFunction, ErrorTypePath, NewUnchecked, TypedCustomFunction, ValueOrExpr,
+    ConstFn, CustomFunction, ErrorTypePath, NewUnchecked, TypedCustomFunction, ValueOrExpr,
 };
 
 pub fn is_doc_attribute(attribute: &syn::Attribute) -> bool {
@@ -65,6 +65,10 @@ pub struct ParseableAttributes<Sanitizer, Validator> {
 
     /// Parsed from `new_unchecked` attribute
     pub new_unchecked: NewUnchecked,
+
+    /// Parsed from `const` attribute,
+    /// Defines if the generated function should be marked with `const`.
+    pub const_fn: ConstFn,
 
     /// Parsed from `default = ` attribute
     pub default: Option<Expr>,
@@ -223,6 +227,7 @@ impl<Sanitizer, Validator> Default for ParseableAttributes<Sanitizer, Validator>
             sanitizers: vec![],
             validation: None,
             new_unchecked: NewUnchecked::Off,
+            const_fn: ConstFn::NoConst,
             default: None,
             derive_traits: vec![],
         }
@@ -286,6 +291,8 @@ where
                 let _eq: Token![=] = input.parse()?;
                 let default_expr: Expr = input.parse()?;
                 attrs.default = Some(default_expr);
+            } else if ident == "const_fn" {
+                attrs.const_fn = ConstFn::Const;
             } else if ident == "new_unchecked" {
                 cfg_if! {
                     if #[cfg(feature = "new_unchecked")] {

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -22,7 +22,7 @@ use crate::{
             traits::GeneratedTraits,
             GenerateNewtype,
         },
-        models::{ErrorTypePath, Guard, TypeName},
+        models::{ConstFn, ErrorTypePath, Guard, TypeName},
     },
     float::models::FloatInnerType,
 };
@@ -40,6 +40,7 @@ where
     fn gen_fn_sanitize(
         inner_type: &Self::InnerType,
         sanitizers: &[Self::Sanitizer],
+        const_fn: ConstFn,
     ) -> TokenStream {
         let transformations: TokenStream = sanitizers
             .iter()
@@ -56,7 +57,7 @@ where
             .collect();
 
         quote!(
-            fn __sanitize__(mut value: #inner_type) -> #inner_type {
+            #const_fn fn __sanitize__(mut value: #inner_type) -> #inner_type {
                 #transformations
                 value
             }
@@ -67,6 +68,7 @@ where
         inner_type: &Self::InnerType,
         error_type_path: &ErrorTypePath,
         validators: &[Self::Validator],
+        const_fn: ConstFn,
     ) -> TokenStream {
         let validations: TokenStream = validators
             .iter()
@@ -117,7 +119,7 @@ where
             .collect();
 
         quote!(
-            fn __validate__(val: &#inner_type) -> core::result::Result<(), #error_type_path> {
+            #const_fn fn __validate__(val: &#inner_type) -> core::result::Result<(), #error_type_path> {
                 let val = *val;
                 #validations
                 Ok(())

--- a/nutype_macros/src/float/parse.rs
+++ b/nutype_macros/src/float/parse.rs
@@ -39,6 +39,7 @@ where
         sanitizers,
         validation,
         new_unchecked,
+        const_fn,
         default,
         derive_traits,
     } = attrs;
@@ -49,6 +50,7 @@ where
     let guard = validate_float_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
+        const_fn,
         guard,
         default,
         derive_traits,

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -24,7 +24,7 @@ use crate::common::{
         traits::GeneratedTraits,
         GenerateNewtype,
     },
-    models::{ErrorTypePath, Guard, TypeName},
+    models::{ConstFn, ErrorTypePath, Guard, TypeName},
 };
 
 impl<T> GenerateNewtype for IntegerNewtype<T>
@@ -39,6 +39,7 @@ where
     fn gen_fn_sanitize(
         inner_type: &Self::InnerType,
         sanitizers: &[Self::Sanitizer],
+        const_fn: ConstFn,
     ) -> TokenStream {
         let transformations: TokenStream = sanitizers
             .iter()
@@ -55,7 +56,7 @@ where
             .collect();
 
         quote!(
-            fn __sanitize__(mut value: #inner_type) -> #inner_type {
+            #const_fn fn __sanitize__(mut value: #inner_type) -> #inner_type {
                 #transformations
                 value
             }
@@ -66,6 +67,7 @@ where
         inner_type: &Self::InnerType,
         error_type_path: &ErrorTypePath,
         validators: &[Self::Validator],
+        const_fn: ConstFn,
     ) -> TokenStream {
         let validations: TokenStream = validators
             .iter()
@@ -109,7 +111,7 @@ where
             .collect();
 
         quote!(
-            fn __validate__(val: &#inner_type) -> ::core::result::Result<(), #error_type_path> {
+            #const_fn fn __validate__(val: &#inner_type) -> ::core::result::Result<(), #error_type_path> {
                 let val = *val;
                 #validations
                 Ok(())

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -39,6 +39,7 @@ where
         sanitizers,
         validation,
         new_unchecked,
+        const_fn,
         default,
         derive_traits,
     } = attrs;
@@ -49,6 +50,7 @@ where
     let guard = validate_integer_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
+        const_fn,
         guard,
         default,
         derive_traits,

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -14,7 +14,7 @@ use crate::{
             tests::gen_test_should_have_valid_default_value, traits::GeneratedTraits,
             GenerateNewtype,
         },
-        models::{ErrorTypePath, Guard, TypeName},
+        models::{ConstFn, ErrorTypePath, Guard, TypeName},
     },
     string::models::{RegexDef, StringInnerType, StringSanitizer, StringValidator},
 };
@@ -42,6 +42,7 @@ impl GenerateNewtype for StringNewtype {
     fn gen_fn_sanitize(
         _inner_type: &Self::InnerType,
         sanitizers: &[Self::Sanitizer],
+        const_fn: ConstFn,
     ) -> TokenStream {
         let transformations: TokenStream = sanitizers
             .iter()
@@ -72,7 +73,7 @@ impl GenerateNewtype for StringNewtype {
             .collect();
 
         quote!(
-            fn __sanitize__(value: String) -> String {
+            #const_fn fn __sanitize__(value: String) -> String {
                 #transformations
                 value
             }
@@ -83,6 +84,7 @@ impl GenerateNewtype for StringNewtype {
         _inner_type: &Self::InnerType,
         error_type_path: &ErrorTypePath,
         validators: &[Self::Validator],
+        const_fn: ConstFn,
     ) -> TokenStream {
         // Indicates that `chars_count` variable needs to be set, which is used within
         // min_len and max_len validations.
@@ -155,7 +157,7 @@ impl GenerateNewtype for StringNewtype {
         };
 
         quote!(
-            fn __validate__(val: &str) -> ::core::result::Result<(), #error_type_path> {
+            #const_fn fn __validate__(val: &str) -> ::core::result::Result<(), #error_type_path> {
                 #chars_count_if_required
                 #validations
                 Ok(())

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -35,6 +35,7 @@ pub fn parse_attributes(
         sanitizers,
         validation,
         new_unchecked,
+        const_fn,
         default,
         derive_traits,
     } = attrs;
@@ -45,6 +46,7 @@ pub fn parse_attributes(
     let guard = validate_string_guard(raw_guard, type_name)?;
     Ok(Attributes {
         new_unchecked,
+        const_fn,
         guard,
         default,
         derive_traits,

--- a/test_suite/tests/float.rs
+++ b/test_suite/tests/float.rs
@@ -803,3 +803,56 @@ mod custom_error {
         assert_eq!(oh_my_float.into_inner(), 99.0);
     }
 }
+
+mod constants {
+    use super::*;
+
+    const fn clamp100(value: f64) -> f64 {
+        if value > 100.0 {
+            return 100.0;
+        } else {
+            return value;
+        }
+    }
+
+    #[test]
+    fn test_const_fn() {
+        #[nutype(const_fn)]
+        pub struct SimpleFloatValue(f64);
+
+        const VALUE: SimpleFloatValue = SimpleFloatValue::new(3.14);
+
+        assert_eq!(VALUE.into_inner(), 3.14);
+    }
+
+    #[test]
+    fn test_const_fn_with_sanitize() {
+        #[nutype(
+            const_fn,
+            sanitize(with = clamp100),
+        )]
+        pub struct SanitizedFloatValue(f64);
+
+        const BIG_VALUE: SanitizedFloatValue = SanitizedFloatValue::new(150.0);
+
+        assert_eq!(BIG_VALUE.into_inner(), 100.0);
+    }
+
+    #[test]
+    fn test_const_fn_with_sanitize_and_validate() {
+        #[nutype(
+            const_fn,
+            sanitize(with = clamp100),
+            validate(greater_or_equal = 0, less_or_equal = 100),
+
+        )]
+        pub struct ValidatedFloat(f64);
+
+        const FIFTY: ValidatedFloat = match ValidatedFloat::try_new(50.0) {
+            Ok(value) => value,
+            Err(_) => panic!("Failed to create ValidatedFloat"),
+        };
+
+        assert_eq!(FIFTY.into_inner(), 50.0);
+    }
+}

--- a/test_suite/tests/ui/common/invalid_constant.rs
+++ b/test_suite/tests/ui/common/invalid_constant.rs
@@ -1,0 +1,15 @@
+use nutype::nutype;
+
+#[nutype(
+    const_fn,
+    validate(greater_or_equal = -273.15)
+)]
+pub struct Celcius(f64);
+
+// This is expected to panic at compile time
+const TOO_COLD: Celcius = match Celcius::try_new(-300.0) {
+    Ok(celcius) => celcius,
+    Err(_) => panic!("Invalid Celcius value"),
+};
+
+fn main() {}

--- a/test_suite/tests/ui/common/invalid_constant.stderr
+++ b/test_suite/tests/ui/common/invalid_constant.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+  --> tests/ui/common/invalid_constant.rs:12:15
+   |
+12 |     Err(_) => panic!("Invalid Celcius value"),
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Invalid Celcius value', $DIR/tests/ui/common/invalid_constant.rs:12:15
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Addresses https://github.com/greyblake/nutype/issues/35

## Changes

* Add `const_fn` attribute, which marks `new` / `try_new` and other underlying functions as `const`


## Example

```rs
#[nutype(
    const_fn,
    validate(greater_or_equal = -1.0, less_or_equal = 1.0)
)]
struct Correlation(f32);

macro_rules! nutype_const {
    ($name:ident, $ty:ty, $value:expr) => {
        const $name: $ty = match <$ty>::try_new($value) {
            Ok(value) => value,
            Err(_) => panic!("Invalid value"),
        };
    };
}

nutype_const!(MAX_CORRELATION, Correlation, 1.0);
```

##  TODO

- [ ] Update docs
- [ ] Update README
- [ ] Update CHANGELOG
- [ ] Fix CI (if necessary)
- [ ] Code review 