### PR TITLE
Add accessor by reference to immutable

### DIFF
--- a/nutype_macros/src/common/gen/mod.rs
+++ b/nutype_macros/src/common/gen/mod.rs
@@ -144,6 +144,10 @@ pub fn gen_impl_into_inner(
             pub fn into_inner(self) -> #inner_type {
                 self.0
             }
+            #[inline]
+            pub fn inner(&self) -> &#inner_type {
+                &self.0
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, if I have:
```
#[nutype(validate(not_empty), derive(Debug, PartialEq, Clone))]
pub struct Username(String);

let u = Username::try_new("Jack").unwrap();
assert_eq!(u.into_inner(), "Jack");
assert_eq!(u.into_inner(), "Jack");
```
At the last line I get the error:
```
use of moved value: `u`
```
Instead, with my change, I can write:
```
let u = Username::try_new("Jack").unwrap();
assert_eq!(u.inner(), "Jack");
assert_eq!(u.inner(), "Jack");
```
