### PR TITLE
Support derive(IntoIterator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### v0.x.x - 2025-xx-xx
 - **[BREAKING]** Fallible `::new()` constructor is removed (was deprecated in 0.4.3).
 - **[FEATURE]** Ability to instantiate types in `const` context, when declared with `const_fn` flag.
+- **[FEATURE]** Support `derive(IntoIterator)` for inner types that implement `IntoIterator`.
 - **[FIX]** Enable `&'a str` as an inner type.
 
 ### v0.5.1 - 2024-12-20

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,12 +1,31 @@
+use core::fmt::Display;
 use nutype::nutype;
 
-#[nutype(
-    derive(Debug),
-    validate(predicate = |name| !name.trim().is_empty())
-)]
-pub struct Name<'a>(&'a str);
+#[nutype(derive(IntoIterator))]
+struct GenericNames<'a, T: Display>(Vec<&'a T>);
+
+#[nutype(derive(IntoIterator))]
+struct StringNames(Vec<String>);
 
 fn main() {
-    let name_error = Name::try_new("  ").unwrap_err();
-    assert_eq!(name_error, NameError::PredicateViolated);
+    let alice = "Alice".to_string();
+    let bob = "Bob".to_string();
+
+    let string_names = StringNames::new(vec![alice, bob]);
+
+    // Test iterator over references
+    {
+        let mut ref_iter = (&string_names).into_iter();
+        assert_eq!(ref_iter.next(), Some(&"Alice".to_string()));
+        assert_eq!(ref_iter.next(), Some(&"Bob".to_string()));
+        assert_eq!(ref_iter.next(), None);
+    }
+
+    // Test iterator over owned values
+    {
+        let mut owned_iter = string_names.into_iter();
+        assert_eq!(owned_iter.next(), Some("Alice".to_string()));
+        assert_eq!(owned_iter.next(), Some("Bob".to_string()));
+        assert_eq!(owned_iter.next(), None);
+    }
 }

--- a/nutype_macros/src/any/gen/traits/into_iter.rs
+++ b/nutype_macros/src/any/gen/traits/into_iter.rs
@@ -1,0 +1,50 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Generics;
+
+use crate::{
+    any::models::AnyInnerType,
+    common::{
+        gen::{add_param, strip_trait_bounds_on_generics},
+        models::TypeName,
+    },
+};
+
+pub fn gen_impl_trait_into_iter(
+    type_name: &TypeName,
+    generics: &Generics,
+    inner_type: &AnyInnerType,
+) -> TokenStream {
+    let generics_without_bounds = strip_trait_bounds_on_generics(generics);
+    let generics_with_iter_lifetime = add_param(generics, quote!('__nutype_iter));
+
+    // In the comments below, we assume that IntoIterator is derived for the following type
+    //
+    //     struct Names<'a, T: Display>(Vec<&'a T>);
+    //
+    // NOTE: We deliberately do not generate an iterator over mutable references, because
+    // this would allow the user to modify the elements of the collection, which may violate
+    // the guarantees that nutype is supposed to provide.
+    quote!(
+        // Implement IntoIterator for the type.
+        impl #generics ::core::iter::IntoIterator for #type_name #generics_without_bounds {    // impl<'a, T: Display> ::core::iter::IntoIterator for Names<'a, T> {
+            type Item = <#inner_type as ::core::iter::IntoIterator>::Item;                     //     type Item = <Vec<&'a T> as ::core::iter::IntoIterator>::Item;
+            type IntoIter = <#inner_type as ::core::iter::IntoIterator>::IntoIter;             //     type IntoIter = <Vec<&'a T> as ::core::iter::IntoIterator>::IntoIter;
+                                                                                               //
+            fn into_iter(self) -> Self::IntoIter {                                             //     fn into_iter(self) -> Self::IntoIter {
+                self.0.into_iter()                                                             //         self.0.into_iter()
+            }                                                                                  //     }
+        }                                                                                      // }
+
+        // IntoIterator for the reference to the type (so it can be iterated over references).
+        impl #generics_with_iter_lifetime ::core::iter::IntoIterator                                  // impl<'a, '__nutype_iter, T: Display> ::core::iter::IntoIterator
+        for &'__nutype_iter #type_name #generics_without_bounds {                                     // for &'__nutype_iter Names<'a, T> {
+            type Item = <&'__nutype_iter #inner_type as ::core::iter::IntoIterator>::Item;            //     type Item = <&'__nutype_iter Vec<&'a T> as ::core::iter::IntoIterator>::Item;
+            type IntoIter = <&'__nutype_iter #inner_type as ::core::iter::IntoIterator>::IntoIter;    //     type IntoIter = <&'__nutype_iter Vec<&'a T> as ::core::iter::IntoIterator>::IntoIter;
+
+            fn into_iter(self) -> Self::IntoIter {                                                    //     fn into_iter(self) -> Self::IntoIter {
+                self.0.iter().into_iter()                                                             //         self.0.iter().into_iter()
+            }                                                                                         //     }
+        }
+    )
+}

--- a/nutype_macros/src/any/gen/traits/mod.rs
+++ b/nutype_macros/src/any/gen/traits/mod.rs
@@ -1,4 +1,5 @@
 pub mod arbitrary;
+pub mod into_iter;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
@@ -45,6 +46,9 @@ impl From<AnyDeriveTrait> for AnyGeneratableTrait {
             AnyDeriveTrait::FromStr => AnyGeneratableTrait::Irregular(AnyIrregularTrait::FromStr),
             AnyDeriveTrait::TryFrom => AnyGeneratableTrait::Irregular(AnyIrregularTrait::TryFrom),
             AnyDeriveTrait::Default => AnyGeneratableTrait::Irregular(AnyIrregularTrait::Default),
+            AnyDeriveTrait::IntoIterator => {
+                AnyGeneratableTrait::Irregular(AnyIrregularTrait::IntoIterator)
+            }
             AnyDeriveTrait::SerdeSerialize => {
                 AnyGeneratableTrait::Irregular(AnyIrregularTrait::SerdeSerialize)
             }
@@ -100,6 +104,7 @@ enum AnyIrregularTrait {
     FromStr,
     TryFrom,
     Default,
+    IntoIterator,
     SerdeSerialize,
     SerdeDeserialize,
     ArbitraryArbitrary,
@@ -174,6 +179,9 @@ fn gen_implemented_traits(
                     Err(syn::Error::new(span, msg))
                 }
             },
+            AnyIrregularTrait::IntoIterator => {
+                Ok(into_iter::gen_impl_trait_into_iter(type_name, generics, inner_type))
+            }
             AnyIrregularTrait::SerdeSerialize => Ok(
                 gen_impl_trait_serde_serialize(type_name, generics)
             ),

--- a/nutype_macros/src/any/models.rs
+++ b/nutype_macros/src/any/models.rs
@@ -44,6 +44,7 @@ pub enum AnyDeriveTrait {
     TryFrom,
     Default,
     Hash,
+    IntoIterator,
 
     // External crates
     SerdeSerialize,

--- a/nutype_macros/src/any/validate.rs
+++ b/nutype_macros/src/any/validate.rs
@@ -88,6 +88,7 @@ fn to_any_derive_trait(
         DeriveTrait::FromStr => Ok(AnyDeriveTrait::FromStr),
         DeriveTrait::TryFrom => Ok(AnyDeriveTrait::TryFrom),
         DeriveTrait::Default => Ok(AnyDeriveTrait::Default),
+        DeriveTrait::IntoIterator => Ok(AnyDeriveTrait::IntoIterator),
         DeriveTrait::SerdeSerialize => Ok(AnyDeriveTrait::SerdeSerialize),
         DeriveTrait::SerdeDeserialize => Ok(AnyDeriveTrait::SerdeDeserialize),
         DeriveTrait::Hash => Ok(AnyDeriveTrait::Hash),

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -354,6 +354,7 @@ pub enum DeriveTrait {
     Display,
     Default,
     Deref,
+    IntoIterator,
 
     // External crates
     //

--- a/nutype_macros/src/common/parse/derive_trait.rs
+++ b/nutype_macros/src/common/parse/derive_trait.rs
@@ -26,6 +26,7 @@ impl Parse for SpannedDeriveTrait {
             "Hash" => DeriveTrait::Hash,
             "Borrow" => DeriveTrait::Borrow,
             "Default" => DeriveTrait::Default,
+            "IntoIterator" => DeriveTrait::IntoIterator,
             "Serialize" => {
                 cfg_if! {
                     if #[cfg(feature = "serde")] {

--- a/nutype_macros/src/float/validate.rs
+++ b/nutype_macros/src/float/validate.rs
@@ -192,6 +192,10 @@ fn to_float_derive_trait(
                 Ok(FloatDeriveTrait::From)
             }
         }
+        DeriveTrait::IntoIterator => Err(syn::Error::new(
+            span,
+            "#[nutype] cannot derive `IntoIterator` trait for float types. Inner type must be a collection type.",
+        )),
         DeriveTrait::TryFrom => Ok(FloatDeriveTrait::TryFrom),
         DeriveTrait::SerdeSerialize => Ok(FloatDeriveTrait::SerdeSerialize),
         DeriveTrait::SerdeDeserialize => Ok(FloatDeriveTrait::SerdeDeserialize),

--- a/nutype_macros/src/integer/validate.rs
+++ b/nutype_macros/src/integer/validate.rs
@@ -115,5 +115,9 @@ fn to_integer_derive_trait(
                 Ok(IntegerDeriveTrait::From)
             }
         }
+        DeriveTrait::IntoIterator => Err(syn::Error::new(
+            span,
+            "#[nutype] cannot derive `IntoIterator` trait for integer types. Inner type must be a collection type.",
+        )),
     }
 }

--- a/nutype_macros/src/string/validate.rs
+++ b/nutype_macros/src/string/validate.rs
@@ -163,6 +163,10 @@ fn to_string_derive_trait(
         }
         DeriveTrait::TryFrom => Ok(StringDeriveTrait::TryFrom),
         DeriveTrait::ArbitraryArbitrary => Ok(StringDeriveTrait::ArbitraryArbitrary),
+        DeriveTrait::IntoIterator => Err(syn::Error::new(
+            span,
+            "#[nutype] cannot derive `IntoIterator` trait for String types. Inner type must be a collection type.",
+        )),
     }
 }
 

--- a/test_suite/tests/any.rs
+++ b/test_suite/tests/any.rs
@@ -1068,3 +1068,47 @@ mod str_reference {
         }
     }
 }
+
+mod into_iter {
+    use nutype::nutype;
+    use std::fmt::Display;
+
+    #[test]
+    fn test_into_iter_for_vector_of_strings() {
+        #[nutype(derive(IntoIterator))]
+        struct StringNames(Vec<String>);
+
+        let alice = "Alice".to_string();
+        let bob = "Bob".to_string();
+        let string_names = StringNames::new(vec![alice, bob]);
+
+        // Test iterator over references
+        {
+            let mut ref_iter = (&string_names).into_iter();
+            assert_eq!(ref_iter.next(), Some(&"Alice".to_string()));
+            assert_eq!(ref_iter.next(), Some(&"Bob".to_string()));
+            assert_eq!(ref_iter.next(), None);
+        }
+
+        // Test iterator over owned values
+        {
+            let mut owned_iter = string_names.into_iter();
+            assert_eq!(owned_iter.next(), Some("Alice".to_string()));
+            assert_eq!(owned_iter.next(), Some("Bob".to_string()));
+            assert_eq!(owned_iter.next(), None);
+        }
+    }
+
+    #[test]
+    fn test_into_iter_for_vector_of_generic_references() {
+        #[nutype(derive(IntoIterator))]
+        struct GenericNames<'a, T: Display + ?Sized>(Vec<&'a T>);
+
+        let names = GenericNames::new(vec!["Alice", "Bob"]);
+
+        let mut iter = names.into_iter();
+        assert_eq!(iter.next(), Some("Alice"));
+        assert_eq!(iter.next(), Some("Bob"));
+        assert_eq!(iter.next(), None);
+    }
+}


### PR DESCRIPTION
Implement support for `derive(IntoIterator)`, which essentially generate `IntoIterator` implementation for `Type` and `&Type`.

Addresses https://github.com/greyblake/nutype/issues/203