### PR TITLE
Add checked operations for integer based newtypes

### DIFF
--- a/nutype_macros/src/any/gen/mod.rs
+++ b/nutype_macros/src/any/gen/mod.rs
@@ -11,7 +11,7 @@ use crate::common::{
     gen::{
         tests::gen_test_should_have_valid_default_value, traits::GeneratedTraits, GenerateNewtype,
     },
-    models::{ConstFn, ErrorTypePath, Guard, TypeName, TypedCustomFunction},
+    models::{CheckedOps, ConstFn, ErrorTypePath, Guard, TypeName, TypedCustomFunction},
 };
 
 use self::error::gen_validation_error_type;
@@ -131,6 +131,22 @@ impl GenerateNewtype for AnyNewtype {
             maybe_default_value,
             guard,
         )
+    }
+
+    fn gen_ops(
+        _type_name: &TypeName,
+        _generics: &Generics,
+        _guard: &Guard<Self::Sanitizer, Self::Validator>,
+        checked_ops: CheckedOps,
+    ) -> Result<TokenStream, syn::Error> {
+        match checked_ops {
+            CheckedOps::Off => Ok(TokenStream::default()),
+            CheckedOps::On => {
+                let span = proc_macro2::Span::call_site();
+                let msg = "Numeric operations can only be implemented for integer types";
+                Err(syn::Error::new(span, msg))
+            }
+        }
     }
 
     fn gen_tests(

--- a/nutype_macros/src/any/parse.rs
+++ b/nutype_macros/src/any/parse.rs
@@ -29,6 +29,7 @@ pub fn parse_attributes(
         const_fn,
         default,
         derive_traits,
+        checked_ops,
     } = attrs;
     let raw_guard = AnyRawGuard {
         sanitizers,
@@ -41,6 +42,7 @@ pub fn parse_attributes(
         guard,
         default,
         derive_traits,
+        checked_ops,
     })
 }
 

--- a/nutype_macros/src/common/gen/traits.rs
+++ b/nutype_macros/src/common/gen/traits.rs
@@ -391,3 +391,104 @@ pub fn gen_impl_trait_default(
         )
     }
 }
+
+/// Generate implementation of checked numeric operations for integer types.
+pub fn gen_impl_checked_ops(
+    type_name: &TypeName,
+    generics: &Generics,
+    maybe_error_type_name: Option<&ErrorTypePath>,
+) -> TokenStream {
+    let generics_without_bounds = strip_trait_bounds_on_generics(generics);
+
+    if let Some(_error_type_name) = maybe_error_type_name {
+        // The case with validation
+        quote! {
+            impl #type_name #generics_without_bounds {
+                #[inline]
+                pub fn checked_add(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_add(rhs.0)?).ok()
+                }
+
+                #[inline]
+                pub fn checked_div(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_div(rhs.0)?).ok()
+                }
+
+                #[inline]
+                pub fn checked_mul(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_mul(rhs.0)?).ok()
+                }
+
+                #[inline]
+                pub fn checked_neg(&self) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_neg()?).ok()
+                }
+
+                #[inline]
+                pub fn checked_rem(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_rem(rhs.0)?).ok()
+                }
+
+                #[inline]
+                pub fn checked_shl(&self, rhs: u32) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_shl(rhs)?).ok()
+                }
+
+                #[inline]
+                pub fn checked_shr(&self, rhs: u32) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_shr(rhs)?).ok()
+                }
+
+                #[inline]
+                pub fn checked_sub(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Self::try_new(self.0.checked_sub(rhs.0)?).ok()
+                }
+            }
+        }
+    } else {
+        // The case without validation
+        quote! {
+            impl #type_name #generics_without_bounds {
+                #[inline]
+                pub fn checked_add(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_add(rhs.0)?))
+                }
+
+                #[inline]
+                pub fn checked_div(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_div(rhs.0)?))
+                }
+
+                #[inline]
+                pub fn checked_mul(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_mul(rhs.0)?))
+                }
+
+                #[inline]
+                pub fn checked_neg(&self) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_neg()?))
+                }
+
+                #[inline]
+                pub fn checked_rem(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_rem(rhs.0)?))
+                }
+
+                #[inline]
+                pub fn checked_shl(&self, rhs: u32) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_shl(rhs)?))
+                }
+
+                #[inline]
+                pub fn checked_shr(&self, rhs: u32) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_shr(rhs)?))
+                }
+
+                #[inline]
+                pub fn checked_sub(&self, rhs: &Self) -> ::core::option::Option<Self> {
+                    Some(Self::new(self.0.checked_sub(rhs.0)?))
+                }
+            }
+        }
+    }
+}

--- a/nutype_macros/src/common/models.rs
+++ b/nutype_macros/src/common/models.rs
@@ -259,6 +259,9 @@ pub struct Attributes<G, DT> {
     /// `new_unchecked` flag
     pub new_unchecked: NewUnchecked,
 
+    /// `checked_ops` flag
+    pub checked_ops: CheckedOps,
+
     /// `const_fn` flag
     pub const_fn: ConstFn,
 
@@ -390,6 +393,16 @@ pub enum NewUnchecked {
     On,
 }
 
+/// The flag indicating generation of checked operations,
+/// as defined in `num_traits::ops::checked` module.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum CheckedOps {
+    #[default]
+    Off,
+
+    On,
+}
+
 /// The flag that indicates the functions must be generated with `const` keyword.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum ConstFn {
@@ -420,6 +433,7 @@ pub struct GenerateParams<IT, Trait, Guard> {
     pub guard: Guard,
     pub new_unchecked: NewUnchecked,
     pub const_fn: ConstFn,
+    pub checked_ops: CheckedOps,
     pub maybe_default_value: Option<syn::Expr>,
 }
 
@@ -466,6 +480,7 @@ pub trait Newtype {
             const_fn,
             default: maybe_default_value,
             derive_traits,
+            checked_ops,
         } = Self::parse_attributes(attrs, &type_name)?;
         let traits = Self::validate(&guard, derive_traits)?;
         let generated_output = Self::generate(GenerateParams {
@@ -477,6 +492,7 @@ pub trait Newtype {
             guard,
             new_unchecked,
             const_fn,
+            checked_ops,
             maybe_default_value,
             inner_type,
         })?;

--- a/nutype_macros/src/common/parse/mod.rs
+++ b/nutype_macros/src/common/parse/mod.rs
@@ -21,7 +21,8 @@ use syn::{
 use crate::common::models::SpannedDeriveTrait;
 
 use super::models::{
-    ConstFn, CustomFunction, ErrorTypePath, NewUnchecked, TypedCustomFunction, ValueOrExpr,
+    CheckedOps, ConstFn, CustomFunction, ErrorTypePath, NewUnchecked, TypedCustomFunction,
+    ValueOrExpr,
 };
 
 pub fn is_doc_attribute(attribute: &syn::Attribute) -> bool {
@@ -75,6 +76,9 @@ pub struct ParseableAttributes<Sanitizer, Validator> {
 
     /// Parsed from `derive(...)` attribute
     pub derive_traits: Vec<SpannedDeriveTrait>,
+
+    /// Parsed from `checked_ops` attribute
+    pub checked_ops: CheckedOps,
 }
 
 enum ValidateAttr<Validator: Parse + Kinded> {
@@ -230,6 +234,7 @@ impl<Sanitizer, Validator> Default for ParseableAttributes<Sanitizer, Validator>
             const_fn: ConstFn::NoConst,
             default: None,
             derive_traits: vec![],
+            checked_ops: CheckedOps::Off,
         }
     }
 }
@@ -306,6 +311,8 @@ where
                         return Err(syn::Error::new(ident.span(), msg));
                     }
                 }
+            } else if ident == "checked_ops" {
+                attrs.checked_ops = CheckedOps::On;
             } else {
                 let msg = format!("Unknown attribute `{ident}`");
                 return Err(syn::Error::new(ident.span(), msg));

--- a/nutype_macros/src/float/gen/mod.rs
+++ b/nutype_macros/src/float/gen/mod.rs
@@ -22,7 +22,7 @@ use crate::{
             traits::GeneratedTraits,
             GenerateNewtype,
         },
-        models::{ConstFn, ErrorTypePath, Guard, TypeName},
+        models::{CheckedOps, ConstFn, ErrorTypePath, Guard, TypeName},
     },
     float::models::FloatInnerType,
 };
@@ -151,6 +151,22 @@ where
             traits,
             guard,
         )
+    }
+
+    fn gen_ops(
+        _type_name: &TypeName,
+        _generics: &Generics,
+        _guard: &Guard<Self::Sanitizer, Self::Validator>,
+        checked_ops: CheckedOps,
+    ) -> Result<TokenStream, syn::Error> {
+        match checked_ops {
+            CheckedOps::Off => Ok(TokenStream::default()),
+            CheckedOps::On => {
+                let span = proc_macro2::Span::call_site();
+                let msg = "Numeric operations can only be implemented for integer types";
+                Err(syn::Error::new(span, msg))
+            }
+        }
     }
 
     fn gen_tests(

--- a/nutype_macros/src/float/parse.rs
+++ b/nutype_macros/src/float/parse.rs
@@ -42,6 +42,7 @@ where
         const_fn,
         default,
         derive_traits,
+        checked_ops,
     } = attrs;
     let raw_guard = FloatRawGuard {
         sanitizers,
@@ -54,6 +55,7 @@ where
         guard,
         default,
         derive_traits,
+        checked_ops,
     })
 }
 

--- a/nutype_macros/src/integer/gen/mod.rs
+++ b/nutype_macros/src/integer/gen/mod.rs
@@ -21,10 +21,10 @@ use crate::common::{
             gen_test_should_have_consistent_lower_and_upper_boundaries,
             gen_test_should_have_valid_default_value,
         },
-        traits::GeneratedTraits,
+        traits::{gen_impl_checked_ops, GeneratedTraits},
         GenerateNewtype,
     },
-    models::{ConstFn, ErrorTypePath, Guard, TypeName},
+    models::{CheckedOps, ConstFn, ErrorTypePath, Guard, TypeName},
 };
 
 impl<T> GenerateNewtype for IntegerNewtype<T>
@@ -143,6 +143,22 @@ where
             maybe_default_value,
             guard,
         )
+    }
+
+    fn gen_ops(
+        type_name: &TypeName,
+        generics: &Generics,
+        guard: &Guard<Self::Sanitizer, Self::Validator>,
+        checked_ops: CheckedOps,
+    ) -> Result<TokenStream, syn::Error> {
+        let checked_ops = match checked_ops {
+            CheckedOps::Off => TokenStream::default(),
+            CheckedOps::On => {
+                let maybe_error_type_name = guard.maybe_error_type_path();
+                gen_impl_checked_ops(type_name, generics, maybe_error_type_name)
+            }
+        };
+        Ok(checked_ops)
     }
 
     fn gen_tests(

--- a/nutype_macros/src/integer/parse.rs
+++ b/nutype_macros/src/integer/parse.rs
@@ -42,6 +42,7 @@ where
         const_fn,
         default,
         derive_traits,
+        checked_ops,
     } = attrs;
     let raw_guard = IntegerRawGuard {
         sanitizers,
@@ -54,6 +55,7 @@ where
         guard,
         default,
         derive_traits,
+        checked_ops,
     })
 }
 

--- a/nutype_macros/src/string/gen/mod.rs
+++ b/nutype_macros/src/string/gen/mod.rs
@@ -14,7 +14,7 @@ use crate::{
             tests::gen_test_should_have_valid_default_value, traits::GeneratedTraits,
             GenerateNewtype,
         },
-        models::{ConstFn, ErrorTypePath, Guard, TypeName},
+        models::{CheckedOps, ConstFn, ErrorTypePath, Guard, TypeName},
     },
     string::models::{RegexDef, StringInnerType, StringSanitizer, StringValidator},
 };
@@ -182,6 +182,22 @@ impl GenerateNewtype for StringNewtype {
         guard: &StringGuard,
     ) -> Result<GeneratedTraits, syn::Error> {
         gen_traits(type_name, generics, traits, maybe_default_value, guard)
+    }
+
+    fn gen_ops(
+        _type_name: &TypeName,
+        _generics: &Generics,
+        _guard: &Guard<Self::Sanitizer, Self::Validator>,
+        checked_ops: CheckedOps,
+    ) -> Result<TokenStream, syn::Error> {
+        match checked_ops {
+            CheckedOps::Off => Ok(TokenStream::default()),
+            CheckedOps::On => {
+                let span = proc_macro2::Span::call_site();
+                let msg = "Numeric operations can only be implemented for integer types";
+                Err(syn::Error::new(span, msg))
+            }
+        }
     }
 
     fn gen_tests(

--- a/nutype_macros/src/string/parse.rs
+++ b/nutype_macros/src/string/parse.rs
@@ -38,6 +38,7 @@ pub fn parse_attributes(
         const_fn,
         default,
         derive_traits,
+        checked_ops,
     } = attrs;
     let raw_guard = StringRawGuard {
         sanitizers,
@@ -50,6 +51,7 @@ pub fn parse_attributes(
         guard,
         default,
         derive_traits,
+        checked_ops,
     })
 }
 

--- a/test_suite/tests/ui/any/attributes/unsupported_attribute.rs
+++ b/test_suite/tests/ui/any/attributes/unsupported_attribute.rs
@@ -1,0 +1,8 @@
+use nutype::nutype;
+
+pub struct Inner(String);
+
+#[nutype(checked_ops)]
+pub struct Name(Inner);
+
+fn main () {}

--- a/test_suite/tests/ui/any/attributes/unsupported_attribute.stderr
+++ b/test_suite/tests/ui/any/attributes/unsupported_attribute.stderr
@@ -1,0 +1,7 @@
+error: Numeric operations can only be implemented for integer types
+ --> tests/ui/any/attributes/unsupported_attribute.rs:5:1
+  |
+5 | #[nutype(checked_ops)]
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `nutype` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test_suite/tests/ui/float/attributes/unsupported_attribute.rs
+++ b/test_suite/tests/ui/float/attributes/unsupported_attribute.rs
@@ -1,0 +1,6 @@
+use nutype::nutype;
+
+#[nutype(checked_ops)]
+pub struct Name(f32);
+
+fn main () {}

--- a/test_suite/tests/ui/float/attributes/unsupported_attribute.stderr
+++ b/test_suite/tests/ui/float/attributes/unsupported_attribute.stderr
@@ -1,0 +1,7 @@
+error: Numeric operations can only be implemented for integer types
+ --> tests/ui/float/attributes/unsupported_attribute.rs:3:1
+  |
+3 | #[nutype(checked_ops)]
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `nutype` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test_suite/tests/ui/string/attributes/unsupported_attribute.rs
+++ b/test_suite/tests/ui/string/attributes/unsupported_attribute.rs
@@ -1,0 +1,6 @@
+use nutype::nutype;
+
+#[nutype(checked_ops)]
+pub struct Name(String);
+
+fn main () {}

--- a/test_suite/tests/ui/string/attributes/unsupported_attribute.stderr
+++ b/test_suite/tests/ui/string/attributes/unsupported_attribute.stderr
@@ -1,0 +1,7 @@
+error: Numeric operations can only be implemented for integer types
+ --> tests/ui/string/attributes/unsupported_attribute.rs:3:1
+  |
+3 | #[nutype(checked_ops)]
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `nutype` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR implements checked arithmetic operations for newtypes whose inner types are integers. It adds an attribute, similar to `new_unchecked` that enable this. 

I considered implementing this as a `num_traits` derives, but those require regular operators to be implemented for those types, so I wanted some feedback on this.

I was also thinking about implementing wrapping and saturating variants, but again I would like to get some feedback on this beforehand.