### PR TITLE
Improve error messages for `len_char_max` and `len_char_min` validators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### v0.x.x - 2025-xx-xx
 - Update Rust edition: 2021 -> 2024
+- Improve error messages for `len_char_max` and `len_char_min` validators.
 
 ### v0.6.1 - 2025-02-09
 - **[FIX]** Fix `derive(Deserialize)` for no_std.

--- a/dummy/src/main.rs
+++ b/dummy/src/main.rs
@@ -1,31 +1,9 @@
-use core::fmt::Display;
 use nutype::nutype;
 
-#[nutype(derive(IntoIterator))]
-struct GenericNames<'a, T: Display>(Vec<&'a T>);
-
-#[nutype(derive(IntoIterator))]
-struct StringNames(Vec<String>);
+#[nutype(derive(Debug), validate(len_char_max = 5, len_char_min = 3))]
+struct Name(String);
 
 fn main() {
-    let alice = "Alice".to_string();
-    let bob = "Bob".to_string();
-
-    let string_names = StringNames::new(vec![alice, bob]);
-
-    // Test iterator over references
-    {
-        let mut ref_iter = (&string_names).into_iter();
-        assert_eq!(ref_iter.next(), Some(&"Alice".to_string()));
-        assert_eq!(ref_iter.next(), Some(&"Bob".to_string()));
-        assert_eq!(ref_iter.next(), None);
-    }
-
-    // Test iterator over owned values
-    {
-        let mut owned_iter = string_names.into_iter();
-        assert_eq!(owned_iter.next(), Some("Alice".to_string()));
-        assert_eq!(owned_iter.next(), Some("Bob".to_string()));
-        assert_eq!(owned_iter.next(), None);
-    }
+    let err = Name::try_new("Alissa").unwrap_err();
+    println!("{err}");
 }

--- a/nutype_macros/src/string/generate/error.rs
+++ b/nutype_macros/src/string/generate/error.rs
@@ -64,10 +64,22 @@ fn gen_impl_display_trait(
 ) -> TokenStream {
     let match_arms = validators.iter().map(|validator| match validator {
         StringValidator::LenCharMax(len_char_max) => quote! {
-             #error_type_path::LenCharMaxViolated => write!(f, "{} is too long. The value length must be less than {:#?} character(s).", stringify!(#type_name), #len_char_max)
+            #error_type_path::LenCharMaxViolated => write!(
+                f,
+                "{} is too long: the maximum valid length is {} character{}.",
+                stringify!(#type_name),
+                #len_char_max,
+                if #len_char_max == 1 { "" } else { "s" }
+            )
         },
         StringValidator::LenCharMin(len_char_min) => quote! {
-             #error_type_path::LenCharMinViolated => write!(f, "{} is too short. The value length must be more than {:#?} character(s).", stringify!(#type_name), #len_char_min)
+            #error_type_path::LenCharMinViolated => write!(
+                f,
+                "{} is too short: the minimum valid length is {} character{}.",
+                stringify!(#type_name),
+                #len_char_min,
+                if #len_char_min == 1 { "" } else { "s" }
+            )
         },
         StringValidator::NotEmpty => quote! {
              #error_type_path::NotEmptyViolated => write!(f, "{} is empty.", stringify!(#type_name))


### PR DESCRIPTION
Fixes https://github.com/greyblake/nutype/issues/215